### PR TITLE
Bump aws-sdk to v2.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cfn-config",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Quickly configure and start AWS CloudFormation stacks",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "optimist": "~0.6.0",
     "inquirer": "~0.4.0",
     "underscore": "~1.5.2",
-    "aws-sdk": "2.0.0-rc13",
+    "aws-sdk": "2.1.7",
     "superenv": "0.0.1",
     "hat": "0.0.3",
     "diff": "1.0.8",


### PR DESCRIPTION
This enables working with `eu-central-1`.

I checked the aws-sdk release notes, there should be no breaking changes between 2.0.0 and 2.1.7.

/cc @yhahn u release new version to npm?