### PR TITLE
Support js modules as CFN templates

### DIFF
--- a/test/compareTemplates.test.js
+++ b/test/compareTemplates.test.js
@@ -34,6 +34,20 @@ tape('compareTemplates', function(assert) {
     });
 });
 
+
+tape('compareTemplates.js', function(assert) {
+    compareTemplates({
+        template: __dirname + '/fixtures/compareTemplates.template.js',
+        name: 'a'
+    }, function(err, data) {
+        assert.ifError(err);
+        assert.equal(typeof data, 'string');
+        assert.equal(data.indexOf('+    "Resources"') !== -1, true);
+        assert.equal(data.indexOf('-    "Resources"') !== -1, true);
+        assert.end();
+    });
+});
+
 tape('unset MockCF', function(assert) {
     config.AWS = origAWS;
     assert.end();

--- a/test/fixtures/compareTemplates.template.js
+++ b/test/fixtures/compareTemplates.template.js
@@ -1,0 +1,4 @@
+module.exports = {
+    "Parameters": {},
+    "Resources": {}
+};

--- a/test/fixtures/local-valid.template.js
+++ b/test/fixtures/local-valid.template.js
@@ -1,0 +1,4 @@
+module.exports = {
+    "Parameters": {},
+    "Resources": {}
+};

--- a/test/readFile.test.js
+++ b/test/readFile.test.js
@@ -15,6 +15,17 @@ tape('readFile-local-valid', function(assert) {
     });
 });
 
+tape('readFile-local-valid-js', function(assert) {
+    readFile(__dirname + '/fixtures/local-valid.template.js', 'us-east-1', function(err, data) {
+        assert.ifError(err);
+        assert.deepEqual(data, {
+            Parameters: {},
+            Resources: {}
+        });
+        assert.end();
+    });
+});
+
 tape('readFile-local-invalid', function(assert) {
     readFile(__dirname + '/fixtures/local-invalid.template', 'us-east-1', function(err, data) {
         assert.equal(err.toString(), 'Error: Unable to parse file');


### PR DESCRIPTION
Adds support for optional use of JS modules as CFN templates. Each module must export a valid CFN template as `module.exports`.

- [x] IRL testing before merge + release

cc @willwhite @emilymcafee 