### PR TITLE
call GetUser only if necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file. For change 
 
 Keep future unreleased changes here
 
+- Look for AWS_ACCOUNT_ID environment variable before calling IAM.GetUser
+
 ## 0.6.0 - 2015-12-07
 
 - Support JS module templates using the `.js` extension

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ update, and delete stacks. Add `~/.cfnrc` with the following properties:
 }
 ```
 
+If the environment variable `AWS_ACCOUNT_ID` is set, it will be used instead of
+making a call to IAM.GetUser in order to determine the AWS account Id for certain
+AWS API calls.
+
 ### Usage
 
 The following commands are available. Run each with `--help` for specific


### PR DESCRIPTION
Fixes #69 - if AWS_ACCOUNT_ID is set in environment, don't call IAM.GetUser.