### PR TITLE
Added logic to handle comparison of parameters with valid null values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.idea
+*~

--- a/index.js
+++ b/index.js
@@ -364,14 +364,18 @@ config.stackInfo = function(options, callback) {
 config.compareParameters = function(lhs, rhs) {
     // Determine deleted parameters and value differences
     _(lhs).each(function(value, key) {
-        if (!rhs[key])
+        if (value == rhs[key]) {
+            // skip, match on nulls
+        } else if (!rhs[key])
             console.log('Remove parameter %s with value %s', key, value);
         else if (value != rhs[key])
             console.log('Change parameter %s from %s to %s', key, value, rhs[key]);
     });
     // Determine new parameters
     _(rhs).each(function(value, key) {
-        if (!lhs[key])
+        if (value == lhs[key]) {
+            // skip, match on nulls
+        } else if (!lhs[key])
             console.log('Add parameter %s with value %s', key, value);
     });
 };

--- a/test/compareParameters.test.js
+++ b/test/compareParameters.test.js
@@ -1,0 +1,45 @@
+var tape = require('tape');
+var util = require('util');
+var config = require('../index.js');
+var compareParameters = config.compareParameters;
+
+tape('compareParameters', function(assert) {
+    var origLog = console.log;
+    var lastLog = null;
+    console.log = function() {
+        origLog.apply(console, arguments);
+        lastLog = util.format.apply(util, arguments);
+    };
+
+    lastLog = null;
+    compareParameters({}, {});
+    assert.deepEqual(lastLog, null, 'no change');
+
+    lastLog = null;
+    compareParameters({ fruit: null }, { fruit: null });
+    assert.deepEqual(lastLog, null, 'no change');
+
+    lastLog = null;
+    compareParameters({ fruit: '' }, { fruit: '' });
+    assert.deepEqual(lastLog, null, 'no change');
+
+    lastLog = null;
+    compareParameters({ fruit: 0 }, { fruit: 0 });
+    assert.deepEqual(lastLog, null, 'no change');
+
+    lastLog = null;
+    compareParameters({ fruit: 'banana' }, { fruit: 'orange' });
+    assert.deepEqual(lastLog, 'Change parameter fruit from banana to orange', '-banana, +orange');
+
+    lastLog = null;
+    compareParameters({}, { fruit: 'orange' });
+    assert.deepEqual(lastLog, 'Add parameter fruit with value orange', '+orange');
+
+    lastLog = null;
+    compareParameters({ fruit: 'banana' }, {});
+    assert.deepEqual(lastLog, 'Remove parameter fruit with value banana', '-banana');
+
+    console.log = origLog;
+    assert.end();
+});
+


### PR DESCRIPTION
When you've got parameters with matching, valid null values, compareParameters generates a lot of noise even though the parameter values are not changing:
```
Remove parameter EuWest1Info with value 
Remove parameter ApSoutheast1Info with value 
Remove parameter ApNortheast1Info with value 
Remove parameter UsWest1Info with value 
Remove parameter SaEast1Info with value 
Remove parameter ApSoutheast2Info with value 
Remove parameter EuCentral1Info with value 
Add parameter UsWest1Info with value 
Add parameter EuCentral1Info with value 
Add parameter EuWest1Info with value 
Add parameter ApNortheast1Info with value 
Add parameter ApSoutheast1Info with value 
Add parameter ApSoutheast2Info with value 
Add parameter SaEast1Info with value 
```

@ianshward, not sure if there is someone else who'd be better to review this. 