### PR TITLE
added full output status for cfn-delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file. For change 
 
 Keep future unreleased changes here
 
+- `cfn-delete` outputs full progress
+
 ## 0.8.2 - 2016-01-27
 
 - Fix `writeConfiguration` to use bucket region

--- a/bin/delete.js
+++ b/bin/delete.js
@@ -28,5 +28,8 @@ if (argv.help) return optimist.showHelp();
 
 config.deleteStack(argv, function(err, result) {
     if (err) throw err;
-    console.log(result ? 'Deleted stack: ' + argv.name : '');
+    config.monitorStack(argv, function(err) {
+        if (err) throw err;
+        console.log(result ? 'Deleted stack: ' + argv.name : '');
+    });
 });

--- a/index.js
+++ b/index.js
@@ -333,7 +333,7 @@ config.deleteStack = function(options, callback) {
         confirmAction('Ready to delete the stack ' + options.name + '?', options.force, function (confirm) {
             if (!confirm) return callback();
             cfn.deleteStack({
-                StackName: options.name
+                StackName: data.Stacks[0].StackId
             }, callback);
         });
     });


### PR DESCRIPTION
The output of `cfn-delete` does not  provide the same level of detail as any other `cfn` command as it needs the `StackId` passed to it instead of the `StackName`. While this could be handled by the caller, I don't see why `cfn-delete` shouldn't use the `StackId` by default to provide equivalent, predicable output detail.