### PR TITLE
function for reading saved config

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,15 @@ config.readStackParameters = function(stackname, region, callback) {
     });
 }
 
+config.readSavedConfig = function(path, callback) {
+    var bucketRegion = env.bucketRegion ? env.bucketRegion : 'us-east-1';
+    path = 's3://' + env.bucket + '/' + path;
+    readFile(path, bucketRegion, function(err, config) {
+        if (err) return callback(new Error('Failed to read configuration file: ' + err.message));
+        callback(null, config);
+    });
+}
+
 config.writeConfiguration = function(template, configuration, callback) {
     var json = JSON.stringify(configuration.Parameters, null, 4);
 

--- a/test/readSavedConfig.test.js
+++ b/test/readSavedConfig.test.js
@@ -1,0 +1,48 @@
+var AWS = require('aws-sdk');
+var s3 = new AWS.S3();
+var tape = require('tape');
+var config = require('../index.js');
+var readSavedConfig = config.readSavedConfig;
+
+var origAWS = config.AWS;
+tape('setup MockS3', function(assert) {
+    config.AWS = { S3: MockS3 };
+    function MockS3() {}
+    MockS3.prototype.getObject = function(options, callback) {
+        if (options.Bucket === 'test' && options.Key === 'valid.template') return callback(null, {
+            Body: new Buffer(JSON.stringify({
+                Secret: 'apples',
+                AnotherSecret: 'oranges'
+            }))
+        });
+        if (options.Key === 'invalid.template') return callback(null, {
+            Body: new Buffer('this is not json')
+        });
+        return callback(new Error('Unsupported by mock'));
+    };
+    assert.end();
+});
+
+config.setCredentials('test', 'test', 'test');
+tape('read saved config', function(assert) {
+    readSavedConfig('valid.template', function(err, data) {
+        assert.ifError(err);
+        assert.deepEqual(data, {
+            Secret: 'apples',
+            AnotherSecret: 'oranges'
+        });
+        assert.end();
+    });
+});
+
+tape('read saved config - invalid', function(assert) {
+    readSavedConfig('invalid.template', function(err, data) {
+        assert.equal(err.toString(), 'Error: Failed to read configuration file: Unable to parse file');
+        assert.end();
+    });
+});
+
+tape('unset MockS3', function(assert) {
+    config.AWS = origAWS;
+    assert.end();
+});


### PR DESCRIPTION
Adds a function for reading configuration files on S3. Can use this to support `info` in the absence of a running CloudFormation stack.