### PR TITLE
Async templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,19 @@ All notable changes to this project will be documented in this file. For change 
 
 Keep future unreleased changes here
 
+- Support asynchronous javascript templates.
+- Change `readFile` method to accept a single options object and a callback.
+
 ## 0.8.5 - 2016-03-01
 
 - fix template path resolution bug in writeConfiguration
 
 ## 0.8.4 - 2016-02-26
+
 - `config.resolveTemplatePath` Uses correct prefix to find the `.cfn.json` files
 
 ## 0.8.3 - 2016-02-19
+
 - `cfn-update -f` checking improved, no longer overriddes other options in other `cfn-config` commands like `cfn-create -c -f` 
 - `cfn-delete` outputs full progress
 

--- a/index.js
+++ b/index.js
@@ -447,7 +447,11 @@ function readFile(filepath, region, callback) {
             ondata(data.Body.toString());
         });
     } else if (/\.js$/.test(filepath)) {
-        callback(null, require(path.resolve(filepath)));
+        var jstemplate = require(path.resolve(filepath));
+        if (typeof jstemplate == 'function') {
+            return jstemplate(callback);
+        }
+        callback(null, jstemplate);
     } else {
         fs.readFile(path.resolve(filepath), function(err, data) {
             if (err) {

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ config.readStackParameters = function(stackname, region, callback) {
 config.readSavedConfig = function(path, callback) {
     var bucketRegion = env.bucketRegion ? env.bucketRegion : 'us-east-1';
     path = 's3://' + env.bucket + '/' + path;
-    readFile(path, bucketRegion, function(err, config) {
+    readFile({template: path, region: bucketRegion}, function(err, config) {
         if (err) return callback(new Error('Failed to read configuration file: ' + err.message));
         callback(null, config);
     });

--- a/test/fixtures/local-async-valid.template.js
+++ b/test/fixtures/local-async-valid.template.js
@@ -1,0 +1,6 @@
+module.exports = function(opts, cb) {
+    cb(null, {
+        "Parameters": {},
+        "Resources": {}
+    });
+};

--- a/test/readFile.test.js
+++ b/test/readFile.test.js
@@ -5,7 +5,7 @@ var config = require('../index.js');
 var readFile = config.readFile;
 
 tape('readFile-local-valid', function(assert) {
-    readFile(__dirname + '/fixtures/local-valid.template', 'us-east-1', function(err, data) {
+    readFile({ template: __dirname + '/fixtures/local-valid.template', region: 'us-east-1' }, function(err, data) {
         assert.ifError(err);
         assert.deepEqual(data, {
             Parameters: {},
@@ -16,7 +16,18 @@ tape('readFile-local-valid', function(assert) {
 });
 
 tape('readFile-local-valid-js', function(assert) {
-    readFile(__dirname + '/fixtures/local-valid.template.js', 'us-east-1', function(err, data) {
+    readFile({ template:__dirname + '/fixtures/local-valid.template.js', region: 'us-east-1' }, function(err, data) {
+        assert.ifError(err);
+        assert.deepEqual(data, {
+            Parameters: {},
+            Resources: {}
+        });
+        assert.end();
+    });
+});
+
+tape('readFile-async-local-valid-js', function(assert) {
+    readFile({ template:__dirname + '/fixtures/local-async-valid.template.js', region: 'us-east-1' }, function(err, data) {
         assert.ifError(err);
         assert.deepEqual(data, {
             Parameters: {},
@@ -27,7 +38,7 @@ tape('readFile-local-valid-js', function(assert) {
 });
 
 tape('readFile-local-invalid', function(assert) {
-    readFile(__dirname + '/fixtures/local-invalid.template', 'us-east-1', function(err, data) {
+    readFile({ template:__dirname + '/fixtures/local-invalid.template', region: 'us-east-1' }, function(err, data) {
         assert.equal(err.toString(), 'Error: Unable to parse file');
         assert.end();
     });
@@ -53,7 +64,7 @@ tape('setup MockS3', function(assert) {
 });
 
 tape('readFile-s3', function(assert) {
-    readFile('s3://mock-bucket/valid.template', 'us-east-1', function(err, data) {
+    readFile({ template:'s3://mock-bucket/valid.template', region: 'us-east-1' }, function(err, data) {
         assert.ifError(err);
         assert.deepEqual(data, {
             Parameters: {},
@@ -64,7 +75,7 @@ tape('readFile-s3', function(assert) {
 });
 
 tape('readFile-s3', function(assert) {
-    readFile('s3://mock-bucket/invalid.template', 'us-east-1', function(err, data) {
+    readFile({ template:'s3://mock-bucket/invalid.template', region: 'us-east-1' }, function(err, data) {
         assert.equal(err.toString(), 'Error: Unable to parse file');
         assert.end();
     });


### PR DESCRIPTION
Allows javascript Cloudformation templates to export a single function that takes accepts and options object and a callback.

The intention is to allow for dynamic templates that could ask for some inputs during creation and then write them into the Cloudformation stack itself. Update calls would then need to extract this info from the template as it exists in Cloudformation to recreate the template without re-prompting the user.