### PR TITLE
cn-north-1 support

### DIFF
--- a/bin/dump.js
+++ b/bin/dump.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+var _ = require('underscore');
+var config = require('..');
+var env = require('superenv')('cfn');
+var optimist = require('optimist');
+
+config.setCredentials(env.accessKeyId, env.secretAccessKey, env.bucket);
+
+var argv = optimist
+    .options('template', {
+        describe: 'AWS CloudFormation template to be dumped to console',
+        demand: true,
+        alias: 't'
+    })
+    .options('region', {
+        describe: 'Which region to output template for',
+        demand: true,
+        alias: 'r'
+    })
+    .argv;
+
+if (argv.help) return optimist.showHelp();
+
+config.readFile(argv, function(err, template) {
+    if (err) return (err);
+    console.log(JSON.stringify(template));
+    process.exit(1);
+});

--- a/index.js
+++ b/index.js
@@ -6,10 +6,10 @@ var AWS = require('aws-sdk');
 var url = require('url');
 var hat = require('hat');
 var jsdiff = require('diff');
-var env = {};
 
 var config = module.exports;
 
+var env = config.env = {};
 config.AWS = AWS;
 
 // Allow override of the default superenv credentials
@@ -17,6 +17,9 @@ config.setCredentials = function (accessKeyId, secretAccessKey, bucket, sessionT
     env.accessKeyId = accessKeyId;
     env.secretAccessKey = secretAccessKey;
     env.bucket = bucket;
+    if (process.env.AWS_REGION && process.env.AWS_REGION.match(/^cn-/)) {
+        env.bucketRegion = process.env.AWS_REGION;
+    }
     if (sessionToken) env.sessionToken = sessionToken;
 };
 
@@ -233,7 +236,7 @@ config.createStack = function(options, callback) {
         confirmAction('Ready to create this stack?', options.force, function (confirm) {
             if (!confirm) return callback();
             var templateName = path.basename(options.template);
-            getTemplateUrl(templateName, configDetails.template, options.region, function(err, url) {
+            config.getTemplateUrl(templateName, configDetails.template, options.region, function(err, url) {
                 if (err) return callback(err);
                 options.templateUrl = url;
                 cfn.createStack(cfnParams(options, configDetails), callback);
@@ -259,7 +262,7 @@ config.updateStack = function(options, callback) {
                 options.beforeUpdate(configDetails, function(err, res) {
                     if (err) return callback(err);
                     var templateName = path.basename(options.template);
-                    getTemplateUrl(templateName, configDetails.template, options.region, function(err, url) {
+                    config.getTemplateUrl(templateName, configDetails.template, options.region, function(err, url) {
                         if (err) return callback(err);
                         options.templateUrl = url;
                         cfn.updateStack(cfnParams(options, configDetails), callback);
@@ -492,7 +495,7 @@ function confirmAction(message, force, callback) {
     });
 }
 
-function getTemplateUrl(templateName, templateBody, region, callback) {
+config.getTemplateUrl = function(templateName, templateBody, region, callback) {
     var s3 = new config.AWS.S3(_(env).extend({ region: region }));
     var iam = new config.AWS.IAM(_(env).extend({ region: region }));
 
@@ -524,9 +527,14 @@ function getTemplateUrl(templateName, templateBody, region, callback) {
                 Body: JSON.stringify(templateBody, null, 4)
             }, function(err, data) {
                 if (err) return callback(err);
-                var host = region === 'us-east-1' ?
-                    'https://s3.amazonaws.com' :
-                    'https://s3-' + region + '.amazonaws.com'
+                var host;
+                if (region == 'us-east-1') {
+                    host = 'https://s3.amazonaws.com';
+                } else if (region.match(/^cn-/)) {
+                    host = 'https://s3.' + region + '.amazonaws.com.cn';
+                } else {
+                    host = 'https://s3-' + region + '.amazonaws.com';
+                }
                 callback(null, [host, bucket, key].join('/'));
             });
         });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "cfn-create": "./bin/create.js",
     "cfn-delete": "./bin/delete.js",
     "cfn-info": "./bin/info.js",
-    "cfn-update": "./bin/update.js"
+    "cfn-update": "./bin/update.js",
+    "cfn-dump": "./bin/dump.js"
   },
   "repository": {
     "type": "git",

--- a/test/localizeChina.test.js
+++ b/test/localizeChina.test.js
@@ -1,0 +1,99 @@
+var AWS = require('aws-sdk');
+var s3 = new AWS.S3();
+var tape = require('tape');
+var config = require('../index.js');
+var getTemplateUrl = config.getTemplateUrl;
+var setCredentials = config.setCredentials;
+var origAWS = config.AWS;
+var env = config.env;
+
+
+tape('setup MockAWS', function(assert) {
+    config.AWS = { S3: MockS3, IAM: MockIAM };
+    function MockS3() {}
+    MockS3.prototype.getObject = function(options, callback) {
+        if (options.Key === 'valid.template') return callback(null, {
+            Body: new Buffer(JSON.stringify({
+                Parameters: {},
+                Resources: {}
+            }))
+        });
+        if (options.Key === 'invalid.template') return callback(null, {
+            Body: new Buffer('this is not json')
+        });
+        return callback(new Error('Unsupported by mock'));
+    };
+    MockS3.prototype.createBucket = function(options, callback) {
+        return callback();
+    };
+    MockS3.prototype.putObject = function(options, callback) {
+        return callback();
+    };
+    function MockIAM() {}
+    MockIAM.prototype.getUser = function(options, callback) {
+        return callback(null, {
+            userData: {
+                User: {
+                    Arn: 'arn:aws:iam::1:test'
+                }
+            }
+        });
+    };
+    assert.end();
+});
+
+tape('getTemplateUrl localizes to cn-north-1', function(assert) {
+    process.env.AWS_ACCOUNT_ID = '1111111';
+    getTemplateUrl('cn','{}','cn-north-1', function(err, data) {
+        assert.ifError(err,'no error');
+        assert.ok(data.match(/https:\/\/s3.cn-north-1.amazonaws.com.cn/),'localized AWSCN cn-north-1 url matched');
+        assert.end();
+    });
+});
+
+tape('getTemplateUrl localizes to cn-west-1', function(assert) {
+    getTemplateUrl('cn','{}','cn-west-1', function(err, data) {
+        assert.ifError(err,'no error');
+        assert.ok(data.match(/https:\/\/s3.cn-west-1.amazonaws.com.cn/),'localized AWSCN cn-west-1 url matched');
+        assert.end();
+    });
+});
+
+tape('getTemplateUrl localizes to us-west-1', function(assert) {
+    getTemplateUrl('cn','{}','us-west-1', function(err, data) {
+        assert.ifError(err,'no error');
+        assert.ok(data.match(/https:\/\/s3.us-west-1.amazonaws.com/),'us-west-1 url matched');
+        assert.end();
+    });
+});
+
+tape('getTemplateUrl localizes to us-east-1', function(assert) {
+    getTemplateUrl('cn','{}','us-east-1', function(err, data) {
+        assert.ifError(err,'no error');
+        assert.ok(data.match(/https:\/\/s3.amazonaws.com/),'us-east-1 url matched');
+        assert.end();
+    });
+});
+
+
+tape('setCredentials bucketRegion override', function(assert) {
+    setCredentials('key','secretKey','cfn-configs');
+    assert.equal(env.bucketRegion, undefined, 'matched undefined bucketRegion');
+    process.env.AWS_REGION = 'cn-north-1';
+    setCredentials('key','secretKey','cfn-configs');
+    assert.equal(env.bucketRegion,'cn-north-1','matched bucketRegion override');
+    delete process.env.AWS_REGION;
+    env = {};
+    setCredentials('key','secretKey','cfn-configs');
+    assert.equal(env.bucketRegion,undefined,'matched bucketRegion default value');
+    assert.end();
+});
+
+
+tape('unset MockAWS', function(assert) {
+    config.AWS = origAWS;
+    config.env = {};
+    assert.equal(config.env.bucketRegion, undefined, 'bucketRegion cleared');
+    assert.equal(config.env.region, undefined, 'region cleared');
+    assert.end();
+});

--- a/test/readSavedConfig.test.js
+++ b/test/readSavedConfig.test.js
@@ -23,8 +23,8 @@ tape('setup MockS3', function(assert) {
     assert.end();
 });
 
-config.setCredentials('test', 'test', 'test');
 tape('read saved config', function(assert) {
+    config.setCredentials('test', 'test', 'test');
     readSavedConfig('valid.template', function(err, data) {
         assert.ifError(err);
         assert.deepEqual(data, {


### PR DESCRIPTION
Adds support for AWS China regions, as well as a template dump-to-console function to help with diagnosis of dynamically generated template errors. 

/cc @ianshward 