### PR TITLE
Revert "Don't prompt for a config file on cfn-update"

### DIFF
--- a/index.js
+++ b/index.js
@@ -254,11 +254,7 @@ config.updateStack = function(options, callback) {
     options.beforeUpdate = options.beforeUpdate || function(configDetails, next) {
         next();
     };
-
-    // Don't prompt for a configuration on updates.
-    var configOptions = _({ force: true }).defaults(options);
-
-    config.configStack(configOptions, function(err, configDetails) {
+    config.configStack(options, function(err, configDetails) {
         if (err) return callback(err);
         var finalize = function() {
             confirmAction('Ready to update the stack?', options.force, function (confirm) {


### PR DESCRIPTION
Reverts mapbox/cfn-config#99, moving too fast.