### PR TITLE
[rewrite] Handle relative paths

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var path = require('path');
 var error = require('fasterror');
 var AWS = require('aws-sdk');
 var s3urls = require('s3urls');
@@ -33,7 +34,7 @@ template.read = function(templatePath, options, callback) {
         return callback(null, templateBody);
       }
 
-      try { templateBody = require(templatePath); }
+      try { templateBody = require(path.resolve(templatePath)); }
       catch (err) { return callback(new template.InvalidTemplateError('Failed to parse %s', templatePath)); }
 
       if (typeof templateBody === 'function') templateBody(options, callback);

--- a/lib/template.js
+++ b/lib/template.js
@@ -9,7 +9,7 @@ var template = module.exports = {};
 /**
  * Read a template from a local file or from S3
  *
- * @param {string} templatePath - the absolute path to a local file or an S3 url
+ * @param {string} templatePath - the absolute or relative path to a local file or an S3 url
  * @param {object} [options] - an object to pass as the first argument to async templates
  * @param {function} callback - a function to receive the template as a JSON object
  */

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -110,6 +110,16 @@ test('[template.read] local sync JS', function(assert) {
   });
 });
 
+test('[template.read] local sync JS (relative path)', function(assert) {
+  var relativePath = path.resolve(__dirname, 'fixtures', 'template-sync.js').replace(process.cwd(), '').substr(1);
+  assert.equal(relativePath[0] !== '/', true, 'relative path: ' + relativePath);
+  template.read(relativePath, function(err, found) {
+    assert.ifError(err, 'success');
+    assert.deepEqual(found, expected, 'got template JSON');
+    assert.end();
+  });
+});
+
 test('[template.read] local async JS with options', function(assert) {
   template.read(path.resolve(__dirname, 'fixtures', 'template-async.js'), { some: 'options' }, function(err, found) {
     assert.ifError(err, 'success');


### PR DESCRIPTION
`require()` is finicky and will fail on a relative path like `cloudformation/mytemplate.js` -- needs to be `./cloudformation/mytemplate.js` or resolved to an absolute path.

Adds test + fix for this.

cc @rclark 