### PR TITLE
Encrypt params during parameter validate function

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -195,7 +195,7 @@ var operations = module.exports.operations = {
       return context.next();
     }
 
-    var questions = template.questions(context.newTemplate, { defaults: context.oldParameters, region: context.region, kms: context.overrides.kms });
+    var questions = template.questions(context.newTemplate, { defaults: context.oldParameters, region: context.region, kmsKeyId: context.overrides.kmsKeyId });
     prompt.parameters(questions, function(err, answers) {
       context.newParameters = answers;
       context.next();

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -195,7 +195,7 @@ var operations = module.exports.operations = {
       return context.next();
     }
 
-    var questions = template.questions(context.newTemplate, { defaults: context.oldParameters }, { region: context.region });
+    var questions = template.questions(context.newTemplate, { defaults: context.oldParameters, region: context.region, kms: context.overrides.kms });
     prompt.parameters(questions, function(err, answers) {
       context.newParameters = answers;
       context.next();

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -195,7 +195,7 @@ var operations = module.exports.operations = {
       return context.next();
     }
 
-    var questions = template.questions(context.newTemplate, { defaults: context.oldParameters });
+    var questions = template.questions(context.newTemplate, { defaults: context.oldParameters }, { region: context.region });
     prompt.parameters(questions, function(err, answers) {
       context.newParameters = answers;
       context.next();

--- a/lib/template.js
+++ b/lib/template.js
@@ -73,17 +73,16 @@ template.read = function(templatePath, options, callback) {
  * @param {object} templateBody - a parsed CloudFormation template
  * @returns {array} a set of questions for user prompting
  */
-template.questions = function(templateBody, overrides, options) {
+template.questions = function(templateBody, overrides) {
   overrides = overrides || {};
   overrides.defaults = overrides.defaults || {};
   overrides.messages = overrides.messages || {};
   overrides.choices = overrides.choices || {};
-
-  options = options || {};
-  options.id = options.id || 'alias/cloudformation';
+  overrides.kms = (overrides.kms && typeof overrides.kms !== 'string') ? 'alias/cloudformation' : overrides.kms;
+  overrides.region = overrides.region || 'us-east-1';
 
   // Not sure where the region should come from, but it's very important here
-  var kms = new AWS.KMS({ region: options.region });
+  var kms = new AWS.KMS({ region: overrides.region });
 
   return Object.keys(templateBody.Parameters || {}).map(function(name) {
     var parameter = templateBody.Parameters[name];
@@ -118,12 +117,16 @@ template.questions = function(templateBody, overrides, options) {
     question.filter = function(input) {
       var done = this.async();
 
-      return kms.encrypt({
-        KeyId: options.id,
-        Plaintext: input
-      }, function(err, encrypted) {
-        done(err, 'secure:' + encrypted.CiphertextBlob.toString('base64'));
-      });
+      if (overrides.kms && parameter.Description.indexOf('[secure]') > -1 && input.slice(0, 7) !== 'secure:') {
+        return kms.encrypt({
+          KeyId: overrides.kms,
+          Plaintext: input
+        }, function(err, encrypted) {
+          done(err, 'secure:' + encrypted.CiphertextBlob.toString('base64'));
+        });
+      } else {
+        return done(null, input);
+      }
     };
 
     if (name in overrides.defaults) question.default = overrides.defaults[name];

--- a/lib/template.js
+++ b/lib/template.js
@@ -79,6 +79,10 @@ template.questions = function(templateBody, overrides, options) {
   overrides.messages = overrides.messages || {};
   overrides.choices = overrides.choices || {};
 
+  options = options || {};
+  options.id = options.id || 'alias/cloudformation';
+
+  // Not sure where the region should come from, but it's very important here
   var kms = new AWS.KMS({ region: options.region });
 
   return Object.keys(templateBody.Parameters || {}).map(function(name) {
@@ -99,7 +103,7 @@ template.questions = function(templateBody, overrides, options) {
       return 'input';
     })();
 
-    question.validate = function(input, callback) {
+    question.validate = function(input) {
       var valid = true;
       if ('MinLength' in parameter) valid = valid && input.length >= parameter.MinLength;
       if ('MaxLength' in parameter) valid = valid && input.length <= parameter.MaxLength;
@@ -108,16 +112,18 @@ template.questions = function(templateBody, overrides, options) {
       if (parameter.AllowedPattern) valid = valid && (new RegExp(parameter.AllowedPattern)).test(input);
       if (parameter.Type === 'List<Number>') valid = valid && input.split(',').every(isNumeric);
 
-      if (valid) {
-        return kms.encrypt({
-          KeyId: 'alias/cloudformation',
-          Plaintext: input
-        }, function(err, encrypted) {
-          return callback(err, encrypted);
-        });
-      } else {
-        return callback(null, false);
-      }
+      return valid;
+    };
+
+    question.filter = function(input) {
+      var done = this.async();
+
+      return kms.encrypt({
+        KeyId: options.id,
+        Plaintext: input
+      }, function(err, encrypted) {
+        done(err, 'secure:' + encrypted.CiphertextBlob.toString('base64'));
+      });
     };
 
     if (name in overrides.defaults) question.default = overrides.defaults[name];

--- a/lib/template.js
+++ b/lib/template.js
@@ -122,7 +122,9 @@ template.questions = function(templateBody, overrides) {
           KeyId: overrides.kms,
           Plaintext: input
         }, function(err, encrypted) {
-          done(err, 'secure:' + encrypted.CiphertextBlob.toString('base64'));
+          if (err || !encrypted) return done(err);
+
+          return done(null, 'secure:' + encrypted.CiphertextBlob.toString('base64'));
         });
       } else {
         return done(null, input);

--- a/lib/template.js
+++ b/lib/template.js
@@ -78,7 +78,7 @@ template.questions = function(templateBody, overrides) {
   overrides.defaults = overrides.defaults || {};
   overrides.messages = overrides.messages || {};
   overrides.choices = overrides.choices || {};
-  overrides.kms = (overrides.kms && typeof overrides.kms !== 'string') ? 'alias/cloudformation' : overrides.kms;
+  overrides.kmsKeyId = (overrides.kmsKeyId && typeof overrides.kmsKeyId !== 'string') ? 'alias/cloudformation' : overrides.kmsKeyId;
   overrides.region = overrides.region || 'us-east-1';
 
   // Not sure where the region should come from, but it's very important here
@@ -117,11 +117,12 @@ template.questions = function(templateBody, overrides) {
     question.filter = function(input) {
       var done = this.async();
 
-      if (overrides.kms && parameter.Description.indexOf('[secure]') > -1 && input.slice(0, 7) !== 'secure:') {
+      if (overrides.kmsKeyId && parameter.Description.indexOf('[secure]') > -1 && input.slice(0, 7) !== 'secure:') {
         return kms.encrypt({
-          KeyId: overrides.kms,
+          KeyId: overrides.kmsKeyId,
           Plaintext: input
         }, function(err, encrypted) {
+          if (err && err.code === 'NotFoundException') return done(new Error('Unable to find KMS encryption key "' + overrides.kmsKeyId + '"'));
           if (err) return done(err);
 
           return done(null, 'secure:' + encrypted.CiphertextBlob.toString('base64'));

--- a/lib/template.js
+++ b/lib/template.js
@@ -73,11 +73,13 @@ template.read = function(templatePath, options, callback) {
  * @param {object} templateBody - a parsed CloudFormation template
  * @returns {array} a set of questions for user prompting
  */
-template.questions = function(templateBody, overrides) {
+template.questions = function(templateBody, overrides, options) {
   overrides = overrides || {};
   overrides.defaults = overrides.defaults || {};
   overrides.messages = overrides.messages || {};
   overrides.choices = overrides.choices || {};
+
+  var kms = new AWS.KMS({ region: options.region });
 
   return Object.keys(templateBody.Parameters || {}).map(function(name) {
     var parameter = templateBody.Parameters[name];
@@ -97,7 +99,7 @@ template.questions = function(templateBody, overrides) {
       return 'input';
     })();
 
-    question.validate = function(input) {
+    question.validate = function(input, callback) {
       var valid = true;
       if ('MinLength' in parameter) valid = valid && input.length >= parameter.MinLength;
       if ('MaxLength' in parameter) valid = valid && input.length <= parameter.MaxLength;
@@ -105,7 +107,17 @@ template.questions = function(templateBody, overrides) {
       if ('MaxValue' in parameter) valid = valid && Number(input) <= parameter.MaxValue;
       if (parameter.AllowedPattern) valid = valid && (new RegExp(parameter.AllowedPattern)).test(input);
       if (parameter.Type === 'List<Number>') valid = valid && input.split(',').every(isNumeric);
-      return valid;
+
+      if (valid) {
+        return kms.encrypt({
+          KeyId: 'alias/cloudformation',
+          Plaintext: input
+        }, function(err, encrypted) {
+          return callback(err, encrypted);
+        });
+      } else {
+        return callback(null, false);
+      }
     };
 
     if (name in overrides.defaults) question.default = overrides.defaults[name];

--- a/lib/template.js
+++ b/lib/template.js
@@ -122,7 +122,7 @@ template.questions = function(templateBody, overrides) {
           KeyId: overrides.kms,
           Plaintext: input
         }, function(err, encrypted) {
-          if (err || !encrypted) return done(err);
+          if (err) return done(err);
 
           return done(null, 'secure:' + encrypted.CiphertextBlob.toString('base64'));
         });

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "d3-queue": "^3.0.2",
     "easy-table": "^1.0.0",
     "fasterror": "^1.0.0",
-    "inquirer": "^1.1.0",
+    "inquirer": "https://github.com/mapbox/Inquirer.js/archive/error-handler.tar.gz",
     "json-diff": "^0.3.1",
     "meow": "^3.7.0",
     "s3urls": "^1.5.2"

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -567,7 +567,7 @@ test('[commands.operations.promptParameters] not force-mode', function(assert) {
 
   sinon.stub(template, 'questions', function(template, overrides) {
     assert.deepEqual(template, { new: 'template' }, 'builds questions for new template');
-    assert.deepEqual(overrides, { defaults: { old: 'parameters' }, kms: undefined, region: undefined }, 'uses old parameters as default values');
+    assert.deepEqual(overrides, { defaults: { old: 'parameters' }, kmsKeyId: undefined, region: undefined }, 'uses old parameters as default values');
     return questions;
   });
 
@@ -593,7 +593,7 @@ test('[commands.operations.promptParameters] not force-mode', function(assert) {
 
 test('[commands.operations.promptParameters] with parameter overrides', function(assert) {
   sinon.stub(template, 'questions', function(template, overrides) {
-    assert.deepEqual(overrides, { defaults: { old: 'overriden' }, kms: 'this is a bomb key', region: 'us-west-2' }, 'uses override parameters');
+    assert.deepEqual(overrides, { defaults: { old: 'overriden' }, kmsKeyId: 'this is a bomb key', region: 'us-west-2' }, 'uses override parameters');
     return { parameter: 'questions' };
   });
 
@@ -605,7 +605,7 @@ test('[commands.operations.promptParameters] with parameter overrides', function
     region: 'us-west-2',
     newTemplate: { new: 'template' },
     oldParameters: { old: 'parameters' },
-    overrides: { parameters: { old: 'overriden' }, kms: 'this is a bomb key' },
+    overrides: { parameters: { old: 'overriden' }, kmsKeyId: 'this is a bomb key' },
     next: function(err) {
       assert.ifError(err, 'success');
       template.questions.restore();

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -567,7 +567,7 @@ test('[commands.operations.promptParameters] not force-mode', function(assert) {
 
   sinon.stub(template, 'questions', function(template, overrides) {
     assert.deepEqual(template, { new: 'template' }, 'builds questions for new template');
-    assert.deepEqual(overrides, { defaults: { old: 'parameters' } }, 'uses old parameters as default values');
+    assert.deepEqual(overrides, { defaults: { old: 'parameters' }, kms: undefined, region: undefined }, 'uses old parameters as default values');
     return questions;
   });
 
@@ -593,7 +593,7 @@ test('[commands.operations.promptParameters] not force-mode', function(assert) {
 
 test('[commands.operations.promptParameters] with parameter overrides', function(assert) {
   sinon.stub(template, 'questions', function(template, overrides) {
-    assert.deepEqual(overrides, { defaults: { old: 'overriden' } }, 'uses override parameters');
+    assert.deepEqual(overrides, { defaults: { old: 'overriden' }, kms: true, region: 'us-west-2' }, 'uses override parameters');
     return { parameter: 'questions' };
   });
 
@@ -602,9 +602,10 @@ test('[commands.operations.promptParameters] with parameter overrides', function
   });
 
   var context = Object.assign({}, basicContext, {
+    region: 'us-west-2',
     newTemplate: { new: 'template' },
     oldParameters: { old: 'parameters' },
-    overrides: { parameters: { old: 'overriden' } },
+    overrides: { parameters: { old: 'overriden' }, kms: true },
     next: function(err) {
       assert.ifError(err, 'success');
       template.questions.restore();

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -593,7 +593,7 @@ test('[commands.operations.promptParameters] not force-mode', function(assert) {
 
 test('[commands.operations.promptParameters] with parameter overrides', function(assert) {
   sinon.stub(template, 'questions', function(template, overrides) {
-    assert.deepEqual(overrides, { defaults: { old: 'overriden' }, kms: true, region: 'us-west-2' }, 'uses override parameters');
+    assert.deepEqual(overrides, { defaults: { old: 'overriden' }, kms: 'this is a bomb key', region: 'us-west-2' }, 'uses override parameters');
     return { parameter: 'questions' };
   });
 
@@ -605,7 +605,7 @@ test('[commands.operations.promptParameters] with parameter overrides', function
     region: 'us-west-2',
     newTemplate: { new: 'template' },
     oldParameters: { old: 'parameters' },
-    overrides: { parameters: { old: 'overriden' }, kms: true },
+    overrides: { parameters: { old: 'overriden' }, kms: 'this is a bomb key' },
     next: function(err) {
       assert.ifError(err, 'success');
       template.questions.restore();

--- a/test/fixtures/template-sync.js
+++ b/test/fixtures/template-sync.js
@@ -27,7 +27,7 @@ module.exports = {
     },
     SecretPassword: {
       Type: 'String',
-      Description: 'Their secret password',
+      Description: '[secure] Their secret password',
       MinLength: 8,
       MaxLength: 24,
       NoEcho: true

--- a/test/fixtures/template.json
+++ b/test/fixtures/template.json
@@ -30,7 +30,7 @@
     },
     "SecretPassword": {
       "Type": "String",
-      "Description": "Their secret password",
+      "Description": "[secure] Their secret password",
       "MinLength": 8,
       "MaxLength": 24,
       "NoEcho": true


### PR DESCRIPTION
Adds step that reaches out to AWS KMS to encrypt parameters during any update or create. This is done during the question generation and parameter validation.

This is a breaking change since it changes `param.validate` to an async function.

cc/ @rclark @yhahn 