### PR TITLE
[rewrite] Use dashed s3 urls

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -288,9 +288,9 @@ actions.templateUrl = function(bucket, region, name) {
   if (region == 'us-east-1') {
     host = 'https://s3.amazonaws.com';
   } else if (region.match(/^cn-/)) {
-    host = 'https://s3.' + region + '.amazonaws.com.cn';
+    host = 'https://s3-' + region + '.amazonaws.com.cn';
   } else {
-    host = 'https://s3.' + region + '.amazonaws.com';
+    host = 'https://s3-' + region + '.amazonaws.com';
   }
 
   return [host, bucket, key].join('/');

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -187,7 +187,12 @@ var operations = module.exports.operations = {
     }
 
     if (context.overrides.force) {
-      context.newParameters = context.oldParameters;
+      context.newParameters = {};
+      Object.keys(context.newTemplate.Parameters).forEach(function(key){
+        if (context.oldParameters[key] !== undefined) {
+          context.newParameters[key] = context.oldParameters[key];
+        }
+      });
       return context.next();
     }
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "inquirer": "^1.1.0",
     "json-diff": "^0.3.1",
     "meow": "^3.7.0",
-    "s3urls": "^1.5.1"
+    "s3urls": "https://github.com/mapbox/s3urls/archive/hopes-dashed.tar.gz"
   }
 }

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -764,14 +764,14 @@ test('[actions.templateUrl] us-east-1', function(assert) {
 
 test('[actions.templateUrl] cn-north-1', function(assert) {
   var url = actions.templateUrl('my-bucket', 'cn-north-1', 'my-stack');
-  var re = /https:\/\/s3.cn-north-1.amazonaws.com.cn\/my-bucket\/.*-my-stack.template.json/;
+  var re = /https:\/\/s3-cn-north-1.amazonaws.com.cn\/my-bucket\/.*-my-stack.template.json/;
   assert.ok(re.test(url), 'expected url');
   assert.end();
 });
 
 test('[actions.templateUrl] eu-central-1', function(assert) {
   var url = actions.templateUrl('my-bucket', 'eu-central-1', 'my-stack');
-  var re = /https:\/\/s3.eu-central-1.amazonaws.com\/my-bucket\/.*-my-stack.template.json/;
+  var re = /https:\/\/s3-eu-central-1.amazonaws.com\/my-bucket\/.*-my-stack.template.json/;
   assert.ok(re.test(url), 'expected url');
   assert.end();
 });

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -527,11 +527,12 @@ test('[commands.operations.promptParameters] force-mode', function(assert) {
   });
 
   var context = Object.assign({}, basicContext, {
-    oldParameters: { old: 'parameters' },
+    newTemplate: { Parameters: { old:{} } },
+    oldParameters: { old: 'parameters', extra: 'value' },
     overrides: { force: true },
     next: function(err) {
       assert.ifError(err, 'success');
-      assert.deepEqual(context.newParameters, context.oldParameters, 'sets new parameters to old values');
+      assert.deepEqual(context.newParameters, { old: 'parameters' }, 'sets new parameters to old values, excluding values not present in template');
       template.questions.restore();
       assert.end();
     }

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -527,7 +527,7 @@ test('[commands.operations.promptParameters] force-mode', function(assert) {
   });
 
   var context = Object.assign({}, basicContext, {
-    newTemplate: { Parameters: { old:{} } },
+    newTemplate: { Parameters: { old: {} } },
     oldParameters: { old: 'parameters', extra: 'value' },
     overrides: { force: true },
     next: function(err) {


### PR DESCRIPTION
I don't know why but CloudFormation + S3 doesn't like the `s3.<region>.amazonaws3.com` form of the URL.

:wine_glass: pairs well with https://github.com/mapbox/s3urls/pull/6.