### PR TITLE
Reject default value not in AllowedValues

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -132,9 +132,12 @@ template.questions = function(templateBody, overrides) {
       }
     };
 
-    if (name in overrides.defaults) question.default = overrides.defaults[name];
     if (name in overrides.choices) question.choices = overrides.choices[name];
     if (name in overrides.messages) question.message = overrides.messages[name];
+    if (name in overrides.defaults) {
+      if (!question.choices || question.choices.indexOf(overrides.defaults[name]) !== -1)
+        question.default = overrides.defaults[name];
+    }
 
     return question;
   });

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -390,3 +390,12 @@ test('[template.questions] handles kms key lookup failure during kms encryption 
   };
   password.filter('hibbities');
 });
+
+test('[template.questions] reject defaults that are not in a list of allowed values', function(assert) {
+  var parameters = { List: { Type: 'String', AllowedValues: ['one', 'two'] } };
+  var overrides = { defaults: { List: 'three' } };
+
+  var questions = template.questions({ Parameters: parameters }, overrides);
+  assert.notEqual(questions[0].default, 'three', 'rejected disallowed default value');
+  assert.end();
+});


### PR DESCRIPTION
If a saved config brings in a default value that is not in a template's list of AllowedValues, then reject the default. This fixes a bug in prompting when the value is not one of the allowed choices.

cc @bsudekum @emilymcafee 