### PR TITLE
Indicate if command was completed

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -230,11 +230,14 @@ module.exports.commandContext = function(config, suffix, operations, callback) {
     templateBucket: config.templateBucket,
     overrides: {},
     oldParameters: {},
-    abort: callback,
+    abort: function(err) {
+      if (err) callback(err, false);
+      else callback(null, false);
+    },
     next: function() {
       i++;
       var operation = operations[i];
-      if (!operation) return callback();
+      if (!operation) return callback(null, true);
       operation(context);
     }
   };

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -326,8 +326,9 @@ test('[commands.commandContext] iterates through operations', function(assert) {
     }
   ];
 
-  var context = commands.commandContext(opts, 'testing', ops, function(err) {
+  var context = commands.commandContext(opts, 'testing', ops, function(err, performed) {
     assert.ifError(err, 'success');
+    assert.equal(performed, true, 'the requested command was performed');
     assert.end();
   });
 
@@ -339,8 +340,9 @@ test('[commands.commandContext] aborts', function(assert) {
     function(context) { context.abort(); }
   ];
 
-  var context = commands.commandContext(opts, 'testing', ops, function(err) {
+  var context = commands.commandContext(opts, 'testing', ops, function(err, performed) {
     assert.ifError(err, 'success');
+    assert.equal(performed, false, 'the requested command was not performed');
     assert.end();
   });
 
@@ -352,8 +354,9 @@ test('[commands.commandContext] aborts with error', function(assert) {
     function(context) { context.abort(new Error('failure')); }
   ];
 
-  var context = commands.commandContext(opts, 'testing', ops, function(err) {
+  var context = commands.commandContext(opts, 'testing', ops, function(err, performed) {
     assert.equal(err.message, 'failure', 'success');
+    assert.equal(performed, false, 'the requested command was not performed');
     assert.end();
   });
 


### PR DESCRIPTION
Commands that are aborted will now return `false` as the second argument to the callback function, and `true` if the command executed to completion. This provides an indication of whether the caller rejected a change.

