### PR TITLE
Format configs on s3 for easier editing

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -226,7 +226,7 @@ actions.saveConfiguration = function(name, bucket, config, parameters, kms, call
     var params = {
       Bucket: bucket,
       Key: lookup.configKey(name, config),
-      Body: JSON.stringify(parameters)
+      Body: JSON.stringify(parameters, null, 2)
     };
 
     if (kms) {


### PR DESCRIPTION
Sometimes we need to manually look at configs or edit them by hand, having them nicely indented makes that easier.

Tests to be fixed after #122 is merged
