### PR TITLE
specify using v4 of request authentication

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -226,7 +226,7 @@ actions.saveConfiguration = function(name, bucket, config, parameters, kms, call
   }
 
   lookup.bucketRegion(bucket, function(err, region) {
-    var s3 = new AWS.S3({ region: region });
+    var s3 = new AWS.S3({ region: region, signatureVersion: 'v4' });
     var params = {
       Bucket: bucket,
       Key: lookup.configKey(name, config),
@@ -262,7 +262,7 @@ actions.saveTemplate = function(templateUrl, templateBody, callback) {
   var region = prefix.length === 4 ? 'cn-north-1' :
     prefix.length === 2 ? 'us-east-1' : prefix[0];
 
-  var s3 = new AWS.S3({ region: region });
+  var s3 = new AWS.S3({ region: region, signatureVersion: 'v4' });
   var params = Object.assign({
     Body: templateBody
   }, s3urls.fromUrl(templateUrl));

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -131,7 +131,7 @@ lookup.configurations = function(name, bucket, callback) {
   lookup.bucketRegion(bucket, function(err, region) {
     if (err) return callback(err);
 
-    var s3 = new AWS.S3({ region: region });
+    var s3 = new AWS.S3({ region: region, signatureVersion: 'v4'});
 
     s3.listObjects({
       Bucket: bucket,
@@ -164,7 +164,7 @@ lookup.configuration = function(name, bucket, config, callback) {
   lookup.bucketRegion(bucket, function(err, region) {
     if (err) return callback(err);
 
-    var s3 = new AWS.S3({ region: region });
+    var s3 = new AWS.S3({ region: region, signatureVersion: 'v4' });
 
     s3.getObject({
       Bucket: bucket,
@@ -199,7 +199,7 @@ lookup.defaultConfiguration = function(s3url, callback) {
   lookup.bucketRegion(params.Bucket, function(err, region) {
     if (err) return callback(null, {});
 
-    var s3 = new AWS.S3({ region: region });
+    var s3 = new AWS.S3({ region: region, signatureVersion: 'v4' });
 
     s3.getObject(params, function(err, data) {
       if (err) return callback(null, {});
@@ -232,7 +232,7 @@ lookup.configKey = function(name, config) {
  * @param {function} callback - a function provided with the bucket's region
  */
 lookup.bucketRegion = function(bucket, callback) {
-  var s3 = new AWS.S3();
+  var s3 = new AWS.S3({signatureVersion: 'v4'});
   s3.getBucketLocation({ Bucket: bucket }, function(err, data) {
     if (err && err.code === 'NoSuchBucket')
       return callback(new lookup.BucketNotFoundError('S3 bucket %s not found', bucket));

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -131,7 +131,7 @@ lookup.configurations = function(name, bucket, callback) {
   lookup.bucketRegion(bucket, function(err, region) {
     if (err) return callback(err);
 
-    var s3 = new AWS.S3({ region: region, signatureVersion: 'v4'});
+    var s3 = new AWS.S3({ region: region, signatureVersion: 'v4' });
 
     s3.listObjects({
       Bucket: bucket,
@@ -232,7 +232,7 @@ lookup.configKey = function(name, config) {
  * @param {function} callback - a function provided with the bucket's region
  */
 lookup.bucketRegion = function(bucket, callback) {
-  var s3 = new AWS.S3({signatureVersion: 'v4'});
+  var s3 = new AWS.S3({ signatureVersion: 'v4' });
   s3.getBucketLocation({ Bucket: bucket }, function(err, data) {
     if (err && err.code === 'NoSuchBucket')
       return callback(new lookup.BucketNotFoundError('S3 bucket %s not found', bucket));

--- a/lib/template.js
+++ b/lib/template.js
@@ -49,7 +49,7 @@ template.read = function(templatePath, options, callback) {
     ));
   }
 
-  var s3 = new AWS.S3();
+  var s3 = new AWS.S3({ signatureVersion: 'v4' });
   s3.getBucketLocation({ Bucket: params.Bucket }, function(err, data) {
     if (err) return s3error(err, callback);
 

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -783,7 +783,7 @@ test('[actions.saveTemplate] bucket does not exist', function(assert) {
   var S3 = AWS.S3;
 
   AWS.S3 = function(params) {
-    assert.deepEqual(params, { region: 'us-east-1' });
+    assert.deepEqual(params, { region: 'us-east-1', signatureVersion: 'v4' });
   };
   AWS.S3.prototype.putObject = function(params, callback) {
     var err = new Error('The specified bucket does not exist');
@@ -842,7 +842,7 @@ test('[actions.saveTemplate] cn-north-1', function(assert) {
   var S3 = AWS.S3;
 
   AWS.S3 = function(params) {
-    assert.deepEqual(params, { region: 'cn-north-1' }, 'parses cn-north-1 from s3 url');
+    assert.deepEqual(params, { region: 'cn-north-1', signatureVersion: 'v4' }, 'parses cn-north-1 from s3 url');
   };
   AWS.S3.prototype.putObject = function(params, callback) {
     assert.deepEqual(params, {
@@ -867,7 +867,7 @@ test('[actions.saveTemplate] eu-central-1', function(assert) {
   var S3 = AWS.S3;
 
   AWS.S3 = function(params) {
-    assert.deepEqual(params, { region: 'eu-central-1' }, 'parses eu-central-1 from s3 url');
+    assert.deepEqual(params, { region: 'eu-central-1', signatureVersion: 'v4' }, 'parses eu-central-1 from s3 url');
   };
   AWS.S3.prototype.putObject = function(params, callback) {
     assert.deepEqual(params, {


### PR DESCRIPTION
"In the Asia Pacific (Mumbai), Asia Pacific (Seoul), EU (Frankfurt) and China (Beijing) regions, Amazon S3 supports only Signature Version 4. In all other regions, Amazon S3 supports both Signature Version 4 and Signature Version 2.

For all AWS regions, AWS SDKs use Signature Version 4 by default to authenticate requests. When using AWS SDKs that were released before May 2016, you may be required to request Signature Version 4 as shown in the following table:"

I think setting this to use signature 4 is ok, rather than expecting everyone to have installed the latest sdk ?

http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html
