### PR TITLE
Add optional metadata override

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -607,7 +607,11 @@ var operations = module.exports.operations = {
     if (!context.overrides.metadata) return context.next();
     context.newTemplate.Metadata = context.newTemplate.Metadata || {};
     for (var k in context.overrides.metadata) {
-      context.newTemplate.Metadata[k] = context.overrides.metadata[k];
+      if (context.newTemplate.Metadata[k] !== undefined) {
+        return context.next(new Error('Metadata.' + k + ' already exists in template'));
+      } else {
+        context.newTemplate.Metadata[k] = context.overrides.metadata[k];
+      }
     }
     context.next();
   }

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -33,6 +33,8 @@ require('colors');
  * default KMS key (id `alias/cloudformation`) for parameter encryption and
  * at-rest configuration encryption, or a string indicating the id of the KMS
  * key that should be used.
+ * @property {object} [metadata] - an object of additional metadata to merge
+ * into the template metadata.
  */
 
 /**
@@ -79,6 +81,7 @@ module.exports = function(config) {
       operations.loadConfig,
       operations.promptParameters,
       operations.confirmCreate,
+      operations.mergeMetadata,
       operations.saveTemplate,
       operations.validateTemplate,
       operations.createStack,
@@ -115,6 +118,7 @@ module.exports = function(config) {
       operations.promptParameters,
       operations.confirmParameters,
       operations.confirmTemplate,
+      operations.mergeMetadata,
       operations.saveTemplate,
       operations.validateTemplate,
       operations.beforeUpdateHook,
@@ -597,6 +601,15 @@ var operations = module.exports.operations = {
       context.overrides.kms,
       finished
     );
+  },
+
+  mergeMetadata: function(context) {
+    if (!context.overrides.metadata) return context.next();
+    context.newTemplate.Metadata = context.newTemplate.Metadata || {};
+    for (var k in context.overrides.metadata) {
+      context.newTemplate.Metadata[k] = context.overrides.metadata[k];
+    }
+    context.next();
   }
 };
 

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1898,3 +1898,23 @@ test('[commands.operations.saveConfig] success', function(assert) {
 
   commands.operations.saveConfig(context);
 });
+
+test('[commands.operations.mergeMetadata]', function(assert) {
+  var context = Object.assign({}, basicContext, {
+    stackRegion: 'us-west-2',
+    newTemplate: { new: 'template' },
+    oldParameters: { old: 'parameters' },
+    overrides: {
+      metadata: {
+        LastDeploy: 'cooper'
+      }
+    },
+    next: function(err) {
+      assert.ifError(err, 'success');
+      assert.deepEqual(context.newTemplate.Metadata, { LastDeploy: 'cooper' });
+      assert.end();
+    }
+  });
+  commands.operations.mergeMetadata(context);
+});
+

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1918,3 +1918,21 @@ test('[commands.operations.mergeMetadata]', function(assert) {
   commands.operations.mergeMetadata(context);
 });
 
+test('[commands.operations.mergeMetadata] error', function(assert) {
+  var context = Object.assign({}, basicContext, {
+    stackRegion: 'us-west-2',
+    newTemplate: { new: 'template', Metadata: { LastDeploy: 'jane' } },
+    oldParameters: { old: 'parameters' },
+    overrides: {
+      metadata: {
+        LastDeploy: 'cooper'
+      }
+    },
+    next: function(err) {
+      assert.equal(err && err.toString(), 'Error: Metadata.LastDeploy already exists in template');
+      assert.end();
+    }
+  });
+  commands.operations.mergeMetadata(context);
+});
+


### PR DESCRIPTION
Add an optional `overrides.metadata` parameter for providing arbitrary metadata keys to be set in the CloudFormation template.

