### PR TITLE
Include JSON/JS error in error message for failed template.read()

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -30,12 +30,12 @@ template.read = function(templatePath, options, callback) {
       if (!/\.js$/.test(templatePath)) {
         templateBody = fs.readFileSync(templatePath);
         try { templateBody = JSON.parse(templateBody); }
-        catch (err) { return callback(new template.InvalidTemplateError('Failed to parse %s', templatePath)); }
+        catch (err) { return callback(new template.InvalidTemplateError('Failed to parse %s: %s', templatePath, err.message)); }
         return callback(null, templateBody);
       }
 
       try { templateBody = require(path.resolve(templatePath)); }
-      catch (err) { return callback(new template.InvalidTemplateError('Failed to parse %s', templatePath)); }
+      catch (err) { return callback(new template.InvalidTemplateError('Failed to parse %s: %s', templatePath, err.message)); }
 
       if (typeof templateBody === 'function') templateBody(options, callback);
       else callback(null, templateBody);

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -20,6 +20,7 @@ test('[template.read] local file does not exist', function(assert) {
 test('[template.read] local file cannot be parsed', function(assert) {
   template.read(path.resolve(__dirname, 'fixtures', 'malformed-template.json'), function(err) {
     assert.ok(err instanceof template.InvalidTemplateError, 'returned expected error');
+    assert.ok(/Failed to parse .*: Unexpected end of input/.test(err.message), 'passthrough parse error');
     assert.end();
   });
 });
@@ -27,6 +28,7 @@ test('[template.read] local file cannot be parsed', function(assert) {
 test('[template.read] local js file cannot be parsed', function(assert) {
   template.read(path.resolve(__dirname, 'fixtures', 'malformed-template.js'), function(err) {
     assert.ok(err instanceof template.InvalidTemplateError, 'returned expected error');
+    assert.ok(/Failed to parse .*: Unexpected token \)/.test(err.message), 'passthrough parse error');
     assert.end();
   });
 });


### PR DESCRIPTION
Refs https://github.com/mapbox/cfn-config/issues/117.

cc @l-r or @rclark for quick review?