### PR TITLE
Better template diff

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -651,8 +651,8 @@ function compareTemplate(existing, desired) {
   // Hacky exemption for Mapbox's Metadata.LastDeployedBy
   existing = JSON.parse(JSON.stringify(existing));
   desired = JSON.parse(JSON.stringify(desired));
-  delete existing.Metadata.LastDeployedBy;
-  delete desired.Metadata.LastDeployedBy;
+  delete (existing.Metadata || {}).LastDeployedBy;
+  delete (desired.Metadata || {}).LastDeployedBy;
   // --------------------------------------------------
 
   existing = JSON.stringify(existing, null, 2);
@@ -665,7 +665,7 @@ function compareTemplate(existing, desired) {
     var strDiff = diff.diffLines(existing, desired);
     var diffText = '';
 
-    strDiff.forEach(function(part){
+    strDiff.forEach(function(part, i){
       var color = part.added ? 'green' : part.removed ? 'red' : 'grey';
       var delimiter = '\n---------------------------------------------\n\n';
 
@@ -674,9 +674,9 @@ function compareTemplate(existing, desired) {
         if (lines.length > 10) {
           var first = lines.slice(0, 3).map((line) => ` ${line}`);
           var last = lines.slice(-3).map((line) => ` ${line}`);
-          diffText += `${first.join('\n')}\n`.grey;
-          diffText += delimiter.grey;
-          diffText += `${last.join('\n')}\n`.grey;
+          if (i !== 0) diffText += `${first.join('\n')}\n`.grey;
+          if (i !== 0 && i !== strDiff.length - 1) diffText += delimiter.grey;
+          if (i !== strDiff.length - 1) diffText += `${last.join('\n')}\n`.grey;
           return;
         }
       }

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var path = require('path');
 var jsonDiff = require('json-diff');
+var diff = require('diff');
 var Table = require('easy-table');
 var actions = require('./actions');
 var lookup = require('./lookup');
@@ -345,7 +346,7 @@ var operations = module.exports.operations = {
   confirmTemplate: function(context) {
     if (context.overrides.force) return context.next();
 
-    var diff = compare(context.oldTemplate, context.newTemplate);
+    var diff = compareTemplate(context.oldTemplate, context.newTemplate);
     if (!diff) return context.next();
 
     prompt.confirm([diff, 'Accept template changes?'].join('\n'), function(err, ready) {
@@ -642,6 +643,53 @@ function compare(existing, desired) {
     return;
   } catch (err) {
     return jsonDiff.diffString(existing, desired);
+  }
+}
+
+function compareTemplate(existing, desired) {
+  // --------------------------------------------------
+  // Hacky exemption for Mapbox's Metadata.LastDeployedBy
+  existing = JSON.parse(JSON.stringify(existing));
+  desired = JSON.parse(JSON.stringify(desired));
+  delete existing.Metadata.LastDeployedBy;
+  delete desired.Metadata.LastDeployedBy;
+  // --------------------------------------------------
+
+  existing = JSON.stringify(existing, null, 2);
+  desired = JSON.stringify(desired, null, 2);
+
+  try {
+    assert.equal(existing, desired);
+    return;
+  } catch (err) {
+    var strDiff = diff.diffLines(existing, desired);
+    var diffText = '';
+
+    strDiff.forEach(function(part){
+      var color = part.added ? 'green' : part.removed ? 'red' : 'grey';
+      var delimiter = '\n---------------------------------------------\n\n';
+
+      if (color === 'grey') {
+        var lines = part.value.split('\n').slice(0, -1);
+        if (lines.length > 10) {
+          var first = lines.slice(0, 3).map((line) => ` ${line}`);
+          var last = lines.slice(-3).map((line) => ` ${line}`);
+          diffText += `${first.join('\n')}\n`.grey;
+          diffText += delimiter.grey;
+          diffText += `${last.join('\n')}\n`.grey;
+          return;
+        }
+      }
+
+      var toPrint = part.value
+        .split('\n')
+        .map((line) => `${!line.length ? '' : part.added ? '+' : part.removed ? '-' : ' '}${line}`)
+        .join('\n')[color];
+
+      diffText += toPrint;
+    });
+
+    return diffText;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,42 +1,43 @@
 {
   "bin": {
     "cfn-config": "bin/cfn-config.js"
-  }, 
-  "license": "BSD-2-Clause", 
-  "name": "@mapbox/cfn-config", 
+  },
+  "license": "BSD-2-Clause",
+  "name": "@mapbox/cfn-config",
   "repository": {
-    "url": "https://github.com/mapbox/cfn-config.git", 
+    "url": "https://github.com/mapbox/cfn-config.git",
     "type": "git"
-  }, 
-  "author": "Mapbox", 
-  "version": "2.6.1", 
+  },
+  "author": "Mapbox",
+  "version": "2.6.1",
   "dependencies": {
-    "fasterror": "^1.0.0", 
-    "meow": "^3.7.0", 
-    "s3urls": "^1.5.2", 
-    "inquirer": "^2.0.0", 
-    "d3-queue": "^3.0.2", 
-    "colors": "^1.1.2", 
-    "easy-table": "^1.0.0", 
-    "cuid": "^1.3.8", 
-    "cfn-stack-event-stream": "0.0.7", 
-    "aws-sdk": "^2.4.3", 
-    "json-diff": "^0.3.1"
-  }, 
+    "aws-sdk": "^2.4.3",
+    "cfn-stack-event-stream": "0.0.7",
+    "colors": "^1.1.2",
+    "cuid": "^1.3.8",
+    "d3-queue": "^3.0.2",
+    "diff": "^3.2.0",
+    "easy-table": "^1.0.0",
+    "fasterror": "^1.0.0",
+    "inquirer": "^2.0.0",
+    "json-diff": "^0.3.1",
+    "meow": "^3.7.0",
+    "s3urls": "^1.5.2"
+  },
   "scripts": {
-    "test": "nyc tape test/*.test.js", 
-    "pretest": "eslint index.js bin lib test/*.js", 
+    "test": "nyc tape test/*.test.js",
+    "pretest": "eslint index.js bin lib test/*.js",
     "coverage": "nyc --reporter html tape test/*.test.js && opener coverage/index.html"
-  }, 
+  },
   "devDependencies": {
-    "opener": "^1.4.1", 
-    "sinon": "^1.17.5", 
-    "eslint": "^2.13.1", 
-    "nyc": "^6.6.1", 
-    "aws-sdk-mock": "1.3.0", 
-    "pinkie-promise": "^2.0.1", 
+    "opener": "^1.4.1",
+    "sinon": "^1.17.5",
+    "eslint": "^2.13.1",
+    "nyc": "^6.6.1",
+    "aws-sdk-mock": "1.3.0",
+    "pinkie-promise": "^2.0.1",
     "tape": "^4.6.0"
-  }, 
-  "main": "index.js", 
+  },
+  "main": "index.js",
   "description": "Quickly configure and start AWS CloudFormation stacks"
 }

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -949,7 +949,7 @@ test('[commands.operations.confirmTemplate] rejected', function(assert) {
   assert.plan(2);
 
   sinon.stub(prompt, 'confirm', function(message, callback) {
-    assert.equal(message, ' {\n\x1b[31m-  old: "template"\x1b[39m\n\x1b[32m+  new: "template"\x1b[39m\n }\n\nAccept template changes?', 'prompted appropriate message');
+    assert.equal(message, '\x1b[90m {\n\x1b[39m\x1b[31m-  "old": "template"\n\x1b[39m\x1b[32m+  "new": "template"\n\x1b[39m\x1b[90m }\x1b[39m\nAccept template changes?', 'prompted appropriate message');
     callback(null, false);
   });
 
@@ -972,13 +972,111 @@ test('[commands.operations.confirmTemplate] accepted', function(assert) {
   assert.plan(2);
 
   sinon.stub(prompt, 'confirm', function(message, callback) {
-    assert.equal(message, ' {\n\x1b[31m-  old: "template"\x1b[39m\n\x1b[32m+  new: "template"\x1b[39m\n }\n\nAccept template changes?', 'prompted appropriate message');
+    assert.equal(message, '\x1b[90m {\n\x1b[39m\x1b[31m-  "old": "template"\n\x1b[39m\x1b[32m+  "new": "template"\n\x1b[39m\x1b[90m }\x1b[39m\nAccept template changes?', 'prompted appropriate message');
     callback(null, true);
   });
 
   var context = Object.assign({}, basicContext, {
     oldTemplate: { old: 'template' },
     newTemplate: { new: 'template' },
+    next: function(err) {
+      assert.ifError(err, 'success');
+      prompt.confirm.restore();
+
+    },
+    abort: function() {
+      assert.fail('should not abort');
+    }
+  });
+
+  commands.operations.confirmTemplate(context);
+});
+
+test('[commands.operations.confirmTemplate] lengthy diff, first unchanged section ignored', function(assert) {
+  assert.plan(2);
+
+  sinon.stub(prompt, 'confirm', function(message, callback) {
+    assert.equal(message, '\x1b[90m   "i": "lines",\n   "j": "lines",\n   "k": "lines",\n\x1b[39m\x1b[31m-  "this": "will change",\n\x1b[39m\x1b[32m+  "this": "has changed",\n\x1b[39m\x1b[90m   "l": "lines",\n   "m": "lines",\n   "n": "lines",\n\x1b[39m\x1b[90m\n---------------------------------------------\n\n\x1b[39m\x1b[90m   "t": "lines",\n   "u": "lines",\n   "v": "lines",\n\x1b[39m\x1b[31m-  "and": "will change too",\n\x1b[39m\x1b[32m+  "and": "has changed",\n\x1b[39m\x1b[90m   "aa": "lines",\n   "ba": "lines",\n   "ca": "lines",\n\x1b[39m\nAccept template changes?', 'prompted appropriate message');
+    callback(null, true);
+  });
+
+  var context = Object.assign({}, basicContext, {
+    oldTemplate: {
+      old: 'template',
+      a: 'lines',
+      b: 'lines',
+      c: 'lines',
+      d: 'lines',
+      e: 'lines',
+      f: 'lines',
+      g: 'lines',
+      h: 'lines',
+      i: 'lines',
+      j: 'lines',
+      k: 'lines',
+      this: 'will change',
+      l: 'lines',
+      m: 'lines',
+      n: 'lines',
+      o: 'lines',
+      p: 'lines',
+      q: 'lines',
+      r: 'lines',
+      s: 'lines',
+      t: 'lines',
+      u: 'lines',
+      v: 'lines',
+      and: 'will change too',
+      aa: 'lines',
+      ba: 'lines',
+      ca: 'lines',
+      da: 'lines',
+      ea: 'lines',
+      fa: 'lines',
+      ga: 'lines',
+      ha: 'lines',
+      ia: 'lines',
+      ja: 'lines',
+      ka: 'lines'
+    },
+    newTemplate: {
+      old: 'template',
+      a: 'lines',
+      b: 'lines',
+      c: 'lines',
+      d: 'lines',
+      e: 'lines',
+      f: 'lines',
+      g: 'lines',
+      h: 'lines',
+      i: 'lines',
+      j: 'lines',
+      k: 'lines',
+      this: 'has changed',
+      l: 'lines',
+      m: 'lines',
+      n: 'lines',
+      o: 'lines',
+      p: 'lines',
+      q: 'lines',
+      r: 'lines',
+      s: 'lines',
+      t: 'lines',
+      u: 'lines',
+      v: 'lines',
+      and: 'has changed',
+      aa: 'lines',
+      ba: 'lines',
+      ca: 'lines',
+      da: 'lines',
+      ea: 'lines',
+      fa: 'lines',
+      ga: 'lines',
+      ha: 'lines',
+      ia: 'lines',
+      ja: 'lines',
+      ka: 'lines'
+    },
     next: function(err) {
       assert.ifError(err, 'success');
       prompt.confirm.restore();
@@ -2076,4 +2174,3 @@ test('[commands.operations.mergeMetadata] error', function(assert) {
   });
   commands.operations.mergeMetadata(context);
 });
-


### PR DESCRIPTION
Implements line-by-line string-based diff on templates that avoids some serious issues that json-diff module has with arrays.

Also hacks in an exemption for `.Metadata.LastDeployedBy` that causes some issue in Mapbox deployment pipelines.
