### PR TITLE
Add CLI flag for setting parameters

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -41,6 +41,7 @@ function parse(args, env) {
                                 prompting, accepting all defaults
         -e, --extended          display resource details with the info command
         -d, --decrypt           decrypt secure parameters with the info command
+        -p, --parameters        JSON string of parameters to override on create/update
     `
   }, {
     alias: {
@@ -51,9 +52,10 @@ function parse(args, env) {
       k: 'kms',
       f: 'force',
       e: 'extended',
-      d: 'decrypt'
+      d: 'decrypt',
+      p: 'parameters'
     },
-    string: ['config-bucket', 'template-bucket', 'name', 'region'],
+    string: ['config-bucket', 'template-bucket', 'name', 'region', 'parameters'],
     boolean: ['force', 'extended', 'decrypt'],
     default: {
       name: path.basename(process.cwd()),
@@ -61,7 +63,8 @@ function parse(args, env) {
       force: false,
       kms: false,
       extended: false,
-      decrypt: false
+      decrypt: false,
+      parameters: undefined
     }
   });
 
@@ -73,11 +76,20 @@ function parse(args, env) {
       ['cfn-config-templates', env.AWS_ACCOUNT_ID, cli.flags.region].join('-');
   }
 
+  if (cli.flags.parameters) {
+    try {
+      cli.flags.p =
+      cli.flags.parameters = JSON.parse(cli.flags.parameters);
+    } catch(err) {
+      throw new Error('Invalid JSON for --parameters: ' + err.message);
+    }
+  }
+
   return {
     command: cli.input[0],
     environment: cli.input[1],
     templatePath: cli.input[2] ? path.resolve(cli.input[2]) : undefined,
-    overrides: { force: cli.flags.force, kms: cli.flags.kms },
+    overrides: { force: cli.flags.force, kms: cli.flags.kms, parameters: cli.flags.parameters },
     options: cli.flags,
     help: cli.help
   };

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -27,9 +27,11 @@ test('[cli.parse] aliases and defaults', function(assert) {
     t: 'template',
     templateBucket: 'template',
     c: 'config',
-    configBucket: 'config'
+    configBucket: 'config',
+    p: undefined,
+    parameters: undefined
   }, 'provided expected options');
-  assert.deepEqual(parsed.overrides, { force: false, kms: false }, 'provided expected overrides');
+  assert.deepEqual(parsed.overrides, { force: false, kms: false, parameters: undefined }, 'provided expected overrides');
   assert.ok(parsed.help, 'provides help text');
   assert.end();
 });
@@ -42,7 +44,8 @@ test('[cli.parse] sets options', function(assert) {
     '-e', '-f', '-d',
     '-k', 'kms-id',
     '-n', 'my-stack',
-    '-r', 'eu-west-1'
+    '-r', 'eu-west-1',
+    '-p', '{}'
   ];
 
   var parsed = cli.parse(args, {});
@@ -63,9 +66,11 @@ test('[cli.parse] sets options', function(assert) {
     t: 'template',
     templateBucket: 'template',
     c: 'config',
-    configBucket: 'config'
+    configBucket: 'config',
+    p: {},
+    parameters: {}
   }, 'provided expected options');
-  assert.deepEqual(parsed.overrides, { force: true, kms: 'kms-id' }, 'provided expected overrides');
+  assert.deepEqual(parsed.overrides, { force: true, kms: 'kms-id', parameters: {} }, 'provided expected overrides');
 
   assert.end();
 });


### PR DESCRIPTION
Adds `--parameters=<json string>` option for setting stack parameters via the command line.