### PR TITLE
Adds preauth function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,16 @@
-module.exports = {
+var AWS = require('aws-sdk');
+
+var cfnConfig = {
   actions: require('./lib/actions'),
   commands: require('./lib/commands'),
   lookup: require('./lib/lookup'),
   prompt: require('./lib/prompt'),
   template: require('./lib/template')
+};
+
+module.exports = cfnConfig;
+
+module.exports.preauth = function(credentials) {
+  AWS.config.credentials = credentials;
+  return cfnConfig;
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,20 @@
+var test = require('tape');
+var AWS = require('aws-sdk');
+var cfnConfig = require('..');
+
+test('[preauth]', function(assert) {
+  cfnConfig.preauth({
+    accessKeyId: 'a',
+    secretAccessKey: 'b'
+  });
+
+  var cfn = new AWS.CloudFormation({ region: 'us-east-1' });
+  assert.deepEqual(cfn.config.credentials, {
+    accessKeyId: 'a',
+    secretAccessKey: 'b'
+  }, 'new clients have preauth credentials');
+
+  AWS.config.credentials = {};
+
+  assert.end();
+});


### PR DESCRIPTION
Adds a function that allows you to preconfigure all aws-sdk clients with a fixed set of credentials. Generally, cfn-config assumes that credentials are set in the environment or through configuration files. This PR lets you specify an explicit set of credentials, which might be useful in scenarios where you've assumed a role, perhaps in another account.

```js
const cfnConfig = require('@mapbox/cfn-config').preauth({
  accessKeyID: 'xxx',
  secretAccessKey: 'yyy',
  sessionToken: 'zzz'
});
```

