### PR TITLE
Save config on update

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -212,15 +212,16 @@ actions.validate = function(region, templateUrl, callback) {
 /**
  * Save a CloudFormation stack's configuration to a local file or S3
  *
- * @param {string} name - the base name of the stack (no suffix)
+ * @param {string} baseName - the base name of the stack (no suffix)
+ * @param {string} stackName - the deployed name of the stack
+ * @param {string} stackRegion - the region of the stack
  * @param {string} bucket - the name of the S3 bucket to save the configuration into
- * @param {string} config - the name of the saved configuration
  * @param {object} parameters - name/value pairs defining the stack configuration to save
  * @param {string} [kms] - if desired, the ID of the AWS KMS master encryption key to use
  * to encrypt this configuration at rest
  * @param {function} callback - a function that will be called when the configuration is saved
  */
-actions.saveConfiguration = function(name, bucket, config, parameters, kms, callback) {
+actions.saveConfiguration = function(baseName, stackName, stackRegion, bucket, parameters, kms, callback) {
   if (typeof kms === 'function') {
     callback = kms;
     kms = null;
@@ -230,7 +231,7 @@ actions.saveConfiguration = function(name, bucket, config, parameters, kms, call
     var s3 = new AWS.S3({ region: region, signatureVersion: 'v4' });
     var params = {
       Bucket: bucket,
-      Key: lookup.configKey(name, config),
+      Key: lookup.configKey(baseName, stackName, stackRegion),
       Body: JSON.stringify(parameters)
     };
 

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -89,7 +89,8 @@ module.exports = function(config) {
       operations.saveTemplate,
       operations.validateTemplate,
       operations.createStack,
-      operations.monitorStack
+      operations.monitorStack,
+      operations.saveConfig
     ], callback);
 
     context.overrides = overrides;
@@ -130,7 +131,8 @@ module.exports = function(config) {
       operations.getChangeset,
       operations.confirmChangeset,
       operations.executeChangeSet,
-      operations.monitorStack
+      operations.monitorStack,
+      operations.saveConfig
     ];
 
     var context = module.exports.commandContext(config, suffix, operationsArray, callback);
@@ -642,12 +644,15 @@ var operations = module.exports.operations = {
       context.next();
     }
 
+    const kms = (context.overrides.kms && typeof context.overrides.kms !== 'string') ? 'alias/cloudformation' : context.overrides.kms;
+
     actions.saveConfiguration(
       context.baseName,
+      context.stackName,
+      context.stackRegion,
       context.configBucket,
-      context.saveName,
-      context.oldParameters,
-      context.overrides.kms,
+      context.newParameters,
+      kms,
       finished
     );
   },

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -230,8 +230,10 @@ lookup.defaultConfiguration = function(s3url, callback) {
  * @param {string} config - the configuration's name
  * @returns {string} an S3 key
  */
-lookup.configKey = function(name, config) {
-  return name + '/' + config + '.cfn.json';
+lookup.configKey = function(name, stackName, region) {
+  return region ?
+    name + '/' + stackName + '-' + region + '.cfn.json' :
+    name + '/' + stackName + '.cfn.json';
 };
 
 /**

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -652,7 +652,7 @@ test('[actions.saveConfiguration] bucket does not exist', function(assert) {
     callback(err);
   });
 
-  actions.saveConfiguration('my-stack', 'my-bucket', 'my-config', parameters, function(err) {
+  actions.saveConfiguration('my-stack', 'my-stack-staging', 'us-east-1', 'my-bucket', parameters, function(err) {
     assert.ok(err instanceof actions.BucketNotFoundError, 'expected error returned');
     AWS.S3.restore();
     assert.end();
@@ -677,7 +677,7 @@ test('[actions.saveConfiguration] unexpected putObject error', function(assert) 
     callback(new Error('unexpected'));
   });
 
-  actions.saveConfiguration('my-stack', 'my-bucket', 'my-config', parameters, function(err) {
+  actions.saveConfiguration('my-stack', 'my-stack-staging', 'us-east-1', 'my-bucket', parameters, function(err) {
     assert.ok(err instanceof actions.S3Error, 'expected error returned');
     AWS.S3.restore();
     assert.end();
@@ -701,7 +701,7 @@ test('[actions.saveConfiguration] success with encryption', function(assert) {
   AWS.stub('S3', 'putObject', function(params, callback) {
     assert.deepEqual(params, {
       Bucket: 'my-bucket',
-      Key: 'my-stack/my-config.cfn.json',
+      Key: 'my-stack/my-stack-staging-us-east-1.cfn.json',
       Body: JSON.stringify(parameters),
       ServerSideEncryption: 'aws:kms',
       SSEKMSKeyId: 'my-key'
@@ -709,7 +709,7 @@ test('[actions.saveConfiguration] success with encryption', function(assert) {
     callback();
   });
 
-  actions.saveConfiguration('my-stack', 'my-bucket', 'my-config', parameters, 'my-key', function(err) {
+  actions.saveConfiguration('my-stack', 'my-stack-staging', 'us-east-1', 'my-bucket', parameters, 'my-key', function(err) {
     assert.ifError(err, 'success');
     AWS.S3.restore();
     assert.end();
@@ -733,13 +733,13 @@ test('[actions.saveConfiguration] success without encryption', function(assert) 
   AWS.stub('S3', 'putObject', function(params, callback) {
     assert.deepEqual(params, {
       Bucket: 'my-bucket',
-      Key: 'my-stack/my-config.cfn.json',
+      Key: 'my-stack/my-stack-staging-us-east-1.cfn.json',
       Body: JSON.stringify(parameters)
     }, 'expected putObject parameters');
     callback();
   });
 
-  actions.saveConfiguration('my-stack', 'my-bucket', 'my-config', parameters, function(err) {
+  actions.saveConfiguration('my-stack', 'my-stack-staging', 'us-east-1', 'my-bucket', parameters, function(err) {
     assert.ifError(err, 'success');
     AWS.S3.restore();
     assert.end();

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -193,7 +193,7 @@ test('[commands.update] no overrides', function(assert) {
   function whenDone() {}
 
   sinon.stub(commands, 'commandContext', function(config, suffix, operations, callback) {
-    assert.equal(operations.length, 13, '13 operations are run');
+    assert.equal(operations.length, 14, '14 operations are run');
     assert.deepEqual(config, opts, 'instantiate context with expected config');
     assert.deepEqual(suffix, 'testing', 'instantiate context with expected suffix');
     assert.ok(operations.every(function(op) { return typeof op === 'function'; }), 'instantiate context with array of operations');
@@ -2176,7 +2176,7 @@ test('[commands.operations.confirmSaveConfig] accept', function(assert) {
 });
 
 test('[commands.operations.saveConfig] bucket not found', function(assert) {
-  sinon.stub(actions, 'saveConfiguration', function(name, bucket, config, parameters, kms, callback) {
+  sinon.stub(actions, 'saveConfiguration', function(baseName, stackName, stackRegion, bucket, parameters, kms, callback) {
     callback(new actions.BucketNotFoundError('failure'));
   });
 
@@ -2195,7 +2195,7 @@ test('[commands.operations.saveConfig] bucket not found', function(assert) {
 });
 
 test('[commands.operations.saveConfig] failure', function(assert) {
-  sinon.stub(actions, 'saveConfiguration', function(name, bucket, config, parameters, kms, callback) {
+  sinon.stub(actions, 'saveConfiguration', function(baseName, stackName, stackRegion, bucket, parameters, kms, callback) {
     callback(new actions.S3Error('failure'));
   });
 
@@ -2214,18 +2214,18 @@ test('[commands.operations.saveConfig] failure', function(assert) {
 });
 
 test('[commands.operations.saveConfig] success', function(assert) {
-  sinon.stub(actions, 'saveConfiguration', function(name, bucket, config, parameters, kms, callback) {
-    assert.equal(name, context.baseName, 'save under correct stack name');
+  sinon.stub(actions, 'saveConfiguration', function(baseName, stackName, stackRegion, bucket, parameters, kms, callback) {
+    assert.equal(baseName, context.baseName, 'save under correct stack name');
+    assert.equal(stackName, context.stackName, 'save under correct stack name');
+    assert.equal(stackRegion, context.stackRegion, 'save under correct stack region');
     assert.equal(bucket, context.configBucket, 'save in correct bucket');
-    assert.equal(config, context.saveName, 'save correct config name');
-    assert.deepEqual(parameters, { old: 'parameters' }, 'save correct config');
+    assert.deepEqual(parameters, { new: 'parameters' }, 'save correct config');
     assert.equal(kms, true, 'use appropriate kms setting');
     callback();
   });
 
   var context = Object.assign({}, basicContext, {
-    saveName: 'chuck',
-    oldParameters: { old: 'parameters' },
+    newParameters: { new: 'parameters' },
     overrides: { kms: true },
     next: function(err) {
       assert.ifError(err, 'success');

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -2220,7 +2220,7 @@ test('[commands.operations.saveConfig] success', function(assert) {
     assert.equal(stackRegion, context.stackRegion, 'save under correct stack region');
     assert.equal(bucket, context.configBucket, 'save in correct bucket');
     assert.deepEqual(parameters, { new: 'parameters' }, 'save correct config');
-    assert.equal(kms, true, 'use appropriate kms setting');
+    assert.equal(kms, 'alias/cloudformation', 'use appropriate kms setting');
     callback();
   });
 

--- a/test/lookups.test.js
+++ b/test/lookups.test.js
@@ -462,7 +462,7 @@ test('[lookup.configuration] bucket location error', function(assert) {
     callback(new Error('failure'));
   });
 
-  lookup.configuration('my-stack', 'my-bucket', 'my-config', function(err) {
+  lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1', function(err) {
     assert.ok(err instanceof lookup.S3Error, 'expected error returned');
     AWS.S3.restore();
     assert.end();
@@ -480,7 +480,7 @@ test('[lookup.configuration] bucket does not exist', function(assert) {
     callback(err);
   });
 
-  lookup.configuration('my-stack', 'my-bucket', 'my-config', function(err) {
+  lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1', function(err) {
     assert.ok(err instanceof lookup.BucketNotFoundError, 'expected error returned');
     AWS.S3.restore();
     assert.end();
@@ -493,12 +493,12 @@ test('[lookup.configuration] S3 error', function(assert) {
   });
 
   AWS.stub('S3', 'getObject', function(params, callback) {
-    assert.equal(params.Key, 'my-stack/my-config.cfn.json', 'getObject called with proper key');
+    assert.equal(params.Key, 'my-stack/my-stack-staging-us-east-1.cfn.json', 'getObject called with proper key');
     var err = new Error('something unexpected');
     callback(err);
   });
 
-  lookup.configuration('my-stack', 'my-bucket', 'my-config', function(err) {
+  lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1', function(err) {
     assert.ok(err instanceof lookup.S3Error, 'expected error returned');
     AWS.S3.restore();
     assert.end();
@@ -516,7 +516,7 @@ test('[lookup.configuration] requested configuration does not exist', function(a
     callback(err);
   });
 
-  lookup.configuration('my-stack', 'my-bucket', 'my-config', function(err) {
+  lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1', function(err) {
     assert.ok(err instanceof lookup.ConfigurationNotFoundError, 'expected error returned');
     AWS.S3.restore();
     assert.end();
@@ -532,7 +532,7 @@ test('[lookup.configuration] cannot parse object data', function(assert) {
     callback(null, { Body: new Buffer('invalid') });
   });
 
-  lookup.configuration('my-stack', 'my-bucket', 'my-config', function(err) {
+  lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1', function(err) {
     assert.ok(err instanceof lookup.InvalidConfigurationError, 'expected error returned');
     AWS.S3.restore();
     assert.end();
@@ -556,13 +556,13 @@ test('[lookup.configuration] success', function(assert) {
   AWS.stub('S3', 'getObject', function(params, callback) {
     assert.deepEqual(params, {
       Bucket: 'my-bucket',
-      Key: 'my-stack/my-config.cfn.json'
+      Key: 'my-stack/my-stack-staging-us-east-1.cfn.json'
     }, 'requested expected configuration');
 
     callback(null, { Body: new Buffer(JSON.stringify(info)) });
   });
 
-  lookup.configuration('my-stack', 'my-bucket', 'my-config', function(err, configuration) {
+  lookup.configuration('my-stack', 'my-bucket', 'my-stack-staging-us-east-1', function(err, configuration) {
     assert.ifError(err, 'success');
     assert.deepEqual(configuration, info, 'returned expected stack info');
     AWS.S3.restore();


### PR DESCRIPTION
## Context

This PR saves every configuration under `<base-name>/<stack-name>-<region>.cfn.json` after every update. We went with using S3 over AWS config for this functionality for latency/simplicity.

## Next actions

- Reviews from @rclark, @emilymcafee and @taraadiseshan 
- Merge & release

cc/ @emilymcafee @kellyoung @rclark @taraadiseshan 