### PR TITLE
Explicit about region in lookups.configurations()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
+## Next version
+
+- specifies region for GetBucketLocation call during `commands.create`
+
 ## 2.12.0 - 2018-02-20
 
 - Automatically save stack configurations to S3 after create or update.

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -509,7 +509,7 @@ var operations = module.exports.operations = {
   createPreamble: function(context) {
     var preamble = d3.queue();
     preamble.defer(template.read, context.templatePath, context.overrides.templateOptions);
-    preamble.defer(lookup.configurations, context.baseName, context.configBucket);
+    preamble.defer(lookup.configurations, context.baseName, context.configBucket, context.stackRegion);
     preamble.await(function(err, templateBody, configs) {
       if (err) {
         var msg = '';

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -132,12 +132,18 @@ lookup.template = function(name, region, callback) {
  *
  * @param {string} name - the base name of the stack (no suffix)
  * @param {string} bucket - the name of the S3 bucket containing saved configurations
+ * @param {string} [region] - the name of the region in which to make lookup requests
  * @param {function} callback - a function that will be provided with a list of
  * saved configuration names
  * @returns
  */
-lookup.configurations = function(name, bucket, callback) {
-  lookup.bucketRegion(bucket, function(err, region) {
+lookup.configurations = function(name, bucket, region, callback) {
+  if (typeof region === 'function') {
+    callback = region;
+    region = undefined;
+  }
+
+  lookup.bucketRegion(bucket, region, function(err, region) {
     if (err) return callback(err);
 
     var s3 = new AWS.S3({ region: region, signatureVersion: 'v4' });
@@ -240,10 +246,16 @@ lookup.configKey = function(name, stackName, region) {
  * Find a bucket's region
  *
  * @param {string} bucket - the name of the bucket
+ * @param {string} [region] - the name of the region in which to make lookup requests
  * @param {function} callback - a function provided with the bucket's region
  */
-lookup.bucketRegion = function(bucket, callback) {
-  var s3 = new AWS.S3({ signatureVersion: 'v4' });
+lookup.bucketRegion = function(bucket, region, callback) {
+  if (typeof region === 'function') {
+    callback = region;
+    region = undefined;
+  }
+
+  var s3 = new AWS.S3({ signatureVersion: 'v4', region: region });
   s3.getBucketLocation({ Bucket: bucket }, function(err, data) {
     if (err && err.code === 'NoSuchBucket')
       return callback(new lookup.BucketNotFoundError('S3 bucket %s not found', bucket));

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1626,7 +1626,7 @@ test('[commands.operations.createPreamble] template not found', function(assert)
     callback(new template.NotFoundError('failure'));
   });
 
-  sinon.stub(lookup, 'configurations', function(name, bucket, callback) {
+  sinon.stub(lookup, 'configurations', function(name, bucket, region, callback) {
     callback();
   });
 
@@ -1649,7 +1649,7 @@ test('[commands.operations.createPreamble] template invalid', function(assert) {
     callback(new template.InvalidTemplateError('failure'));
   });
 
-  sinon.stub(lookup, 'configurations', function(name, bucket, callback) {
+  sinon.stub(lookup, 'configurations', function(name, bucket, region, callback) {
     callback();
   });
 
@@ -1672,7 +1672,7 @@ test('[commands.operations.createPreamble] config bucket not found', function(as
     callback();
   });
 
-  sinon.stub(lookup, 'configurations', function(name, bucket, callback) {
+  sinon.stub(lookup, 'configurations', function(name, bucket, region, callback) {
     callback(new lookup.BucketNotFoundError('failure'));
   });
 
@@ -1695,7 +1695,7 @@ test('[commands.operations.createPreamble] failed to read configurations', funct
     callback();
   });
 
-  sinon.stub(lookup, 'configurations', function(name, bucket, callback) {
+  sinon.stub(lookup, 'configurations', function(name, bucket, region, callback) {
     callback(new lookup.S3Error('failure'));
   });
 
@@ -1720,7 +1720,7 @@ test('[commands.operations.createPreamble] success', function(assert) {
     callback(null, { new: 'template' });
   });
 
-  sinon.stub(lookup, 'configurations', function(name, bucket, callback) {
+  sinon.stub(lookup, 'configurations', function(name, bucket, region, callback) {
     assert.equal(name, context.baseName, 'lookup correct stack configurations');
     assert.equal(bucket, context.configBucket, 'lookup in correct bucket');
     callback(null, ['config']);


### PR DESCRIPTION
A `GetBucketLocation` API call needs to be made in a region that is applicable to the account that bucket is hosted in. Example: requests about AWS China buckets must be made in one of the AWS China regions. The SDK default is `us-east-1` and that breaks.

This PR looks at the region of the stack being deployed, and provides that in order to read saved configurations on S3. This results in the `GetBucketLocation` call getting made in an appropriate region.