### PR TITLE
Add skip notice.

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -374,7 +374,7 @@ var operations = module.exports.operations = {
       }).length;
 
       if (preapproved) {
-        console.log('Skipped confirming parameters: diff preapproved.');
+        console.log('Auto-confirming parameter changes... Changes were pre-approved in another region.');
         context.overrides.skipConfirmParameters = true;
         return context.next();
       }
@@ -405,7 +405,7 @@ var operations = module.exports.operations = {
       }).length;
 
       if (preapproved) {
-        console.log('Skipped confirming template: diff preapproved.');
+        console.log('Auto-confirming template changes... Changes were pre-approved in another region.');
         context.overrides.skipConfirmTemplate = true;
         return context.next();
       }

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 var assert = require('assert');
 var path = require('path');
 var jsonDiff = require('json-diff');
@@ -373,6 +374,7 @@ var operations = module.exports.operations = {
       }).length;
 
       if (preapproved) {
+        console.log('Skipped confirming parameters: diff preapproved.');
         context.overrides.skipConfirmParameters = true;
         return context.next();
       }
@@ -403,6 +405,7 @@ var operations = module.exports.operations = {
       }).length;
 
       if (preapproved) {
+        console.log('Skipped confirming template: diff preapproved.');
         context.overrides.skipConfirmTemplate = true;
         return context.next();
       }

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -970,7 +970,7 @@ test('[commands.operations.confirmParameters] preapproved', function(assert) {
       preapproved: { parameters: [' {\n\u001b[32m+  newones: "too"\u001b[39m\n }\n'] }
     },
     next: function() {
-      assert.ok(console.log.calledWith('Skipped confirming parameters: diff preapproved.'), 'Skip notice printed');
+      assert.ok(console.log.calledWith('Auto-confirming parameter changes... Changes were pre-approved in another region.'), 'Skip notice printed');
       assert.pass('skipped prompting');
       assert.ok(context.overrides.skipConfirmParameters, 'sets skipConfirmParameters');
       console.log.restore();
@@ -1083,7 +1083,7 @@ test('[commands.operations.confirmTemplate] preapproved', function(assert) {
       }
     },
     next: function(err) {
-      assert.ok(console.log.calledWith('Skipped confirming template: diff preapproved.'), 'Skip notice printed');
+      assert.ok(console.log.calledWith('Auto-confirming template changes... Changes were pre-approved in another region.'), 'Skip notice printed');
       assert.ifError(err, 'should proceed');
       assert.ok(context.overrides.skipConfirmTemplate, 'sets skipConfirmTemplate');
       assert.end();

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 var path = require('path');
 var test = require('tape');
 var sinon = require('sinon');
@@ -960,6 +961,8 @@ test('[commands.operations.confirmParameters] no difference', function(assert) {
 });
 
 test('[commands.operations.confirmParameters] preapproved', function(assert) {
+  sinon.stub(console, 'log');
+
   var context = Object.assign({}, basicContext, {
     oldParameters: { old: 'parameters' },
     newParameters: { old: 'parameters', newones: 'too' },
@@ -967,8 +970,10 @@ test('[commands.operations.confirmParameters] preapproved', function(assert) {
       preapproved: { parameters: [' {\n\u001b[32m+  newones: "too"\u001b[39m\n }\n'] }
     },
     next: function() {
+      assert.ok(console.log.calledWith('Skipped confirming parameters: diff preapproved.'), 'Skip notice printed');
       assert.pass('skipped prompting');
       assert.ok(context.overrides.skipConfirmParameters, 'sets skipConfirmParameters');
+      console.log.restore();
       assert.end();
     }
   });
@@ -1068,6 +1073,7 @@ test('[commands.operations.confirmTemplate] force-mode', function(assert) {
 });
 
 test('[commands.operations.confirmTemplate] preapproved', function(assert) {
+  sinon.stub(console, 'log');
   var context = Object.assign({}, basicContext, {
     oldTemplate: { old: 'template' },
     newTemplate: { new: 'template' },
@@ -1077,9 +1083,11 @@ test('[commands.operations.confirmTemplate] preapproved', function(assert) {
       }
     },
     next: function(err) {
+      assert.ok(console.log.calledWith('Skipped confirming template: diff preapproved.'), 'Skip notice printed');
       assert.ifError(err, 'should proceed');
       assert.ok(context.overrides.skipConfirmTemplate, 'sets skipConfirmTemplate');
       assert.end();
+      console.log.restore();
     },
     abort: function(err) {
       assert.ifError(err, 'should not proceed');


### PR DESCRIPTION
This PR adds a notice when changeset confirmation is skipped for: 
* pre-approved template diffs
* pre-approved param diffs

Print notice when skipping parameters. 

I notice we're usually using the pipe-stdout in this repo, instead of  console.log to make the event stream printing working. any objection to using console log instead for this case? 