### PR TITLE
Use stack's AWS region when looking up config bucket location

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -210,7 +210,7 @@ actions.validate = function(region, templateUrl, callback) {
 };
 
 /**
- * Save a CloudFormation stack's configuration to a local file or S3
+ * Save a CloudFormation stack's configuration to S3
  *
  * @param {string} baseName - the base name of the stack (no suffix)
  * @param {string} stackName - the deployed name of the stack
@@ -227,7 +227,7 @@ actions.saveConfiguration = function(baseName, stackName, stackRegion, bucket, p
     kms = null;
   }
 
-  lookup.bucketRegion(bucket, function(err, region) {
+  lookup.bucketRegion(bucket, stackRegion, function(err, region) {
     var s3 = new AWS.S3({ region: region, signatureVersion: 'v4' });
     var params = {
       Bucket: bucket,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git"
   },
   "author": "Mapbox",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "dependencies": {
     "aws-sdk": "^2.4.3",
     "cfn-stack-event-stream": "0.0.7",

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -776,7 +776,8 @@ test('[actions.saveConfiguration] config bucket in a different region', function
   actions.saveConfiguration('my-stack', 'my-stack-staging', 'eu-west-1', 'my-bucket', parameters, function(err) {
     assert.ifError(err, 'success');
     assert.true(AWS.S3.calledTwice, 's3 client setup called twice');
-    assert.ok(AWS.S3.secondCall.calledWithExactly({ region: 'us-east-2', signatureVersion: 'v4' }), 's3 client created correctly');
+    assert.ok(AWS.S3.firstCall.calledWithExactly({ signatureVersion: 'v4', region: 'eu-west-1' }), 'first s3 client created correctly');
+    assert.ok(AWS.S3.secondCall.calledWithExactly({ region: 'us-east-2', signatureVersion: 'v4' }), 'second s3 client created correctly');
     AWS.S3.restore();
     assert.end();
   });

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -750,6 +750,38 @@ test('[actions.saveConfiguration] success without encryption', function(assert) 
   });
 });
 
+test('[actions.saveConfiguration] config bucket in a different region', function(assert) {
+  var parameters = {
+    Name: 'Chuck',
+    Age: 18,
+    Handedness: 'left',
+    Pets: 'Duck,Wombat',
+    LuckyNumbers: '3,7,42',
+    SecretPassword: 'secret'
+  };
+
+  AWS.stub('S3', 'getBucketLocation', function(params, callback) {
+    callback(null, { LocationConstraint: 'us-east-2' });
+  });
+
+  AWS.stub('S3', 'putObject', function(params, callback) {
+    assert.deepEqual(params, {
+      Bucket: 'my-bucket',
+      Key: 'my-stack/my-stack-staging-eu-west-1.cfn.json',
+      Body: JSON.stringify(parameters)
+    }, 'expected putObject parameters');
+    callback();
+  });
+
+  actions.saveConfiguration('my-stack', 'my-stack-staging', 'eu-west-1', 'my-bucket', parameters, function(err) {
+    assert.ifError(err, 'success');
+    assert.true(AWS.S3.calledTwice, 's3 client setup called twice');
+    assert.ok(AWS.S3.secondCall.calledWithExactly({ region: 'us-east-2', signatureVersion: 'v4' }), 's3 client created correctly');
+    AWS.S3.restore();
+    assert.end();
+  });
+});
+
 test('[actions.templateUrl] us-east-1', function(assert) {
   var url = actions.templateUrl('my-bucket', 'us-east-1', 'my-stack');
   var re = /https:\/\/s3.amazonaws.com\/my-bucket\/.*-my-stack.template.json/;


### PR DESCRIPTION
Some regions/accounts, like AWS China, apparently use a different token type/format when making AWS requests. You can expose this difference via an "InvalidToken" error message easily by running an awscli command with a AWS-CN access key and secret key but not providing the `cn-north-1` region. An error with the description "The provided token is malformed or otherwise invalid." will be thrown.

In cfn-config, this would occur when saveConfiguration was called (at the end of a stack create, update, etc.). This was due to how a helper function `lookup.bucketRegion()` was called: the corresponding S3 client used to upload the configuration would always have a region set to `undefined`.

This PR changes this behavior by passing the stack's region name to `lookup.BucketRegion()`. It doesn't matter what region the S3 bucket actually exists in to perform the [`GET Bucket Location` API call](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETlocation.html), the purpose of the call is to reveal that exact thing.

I also added a test case for this behavior change.