### PR TITLE
Update dependency inquirer v6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-6+8IgqoLxIFBeflBGR6EZsIRAV8=",
       "dev": true,
       "requires": {
-        "aws-sdk": "^2.5.0",
-        "sinon": "^1.17.5",
-        "traverse": "^0.6.6"
+        "aws-sdk": "2.197.0",
+        "sinon": "1.17.7",
+        "traverse": "0.6.6"
       }
     },
     "acorn": {
@@ -27,7 +27,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "^3.0.4"
+        "acorn": "3.3.0"
       },
       "dependencies": {
         "acorn": {
@@ -44,8 +44,8 @@
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "json-stable-stringify": "^1.0.1"
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
       }
     },
     "ajv-keywords": {
@@ -57,7 +57,8 @@
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
     },
     "ansi-regex": {
       "version": "3.0.0",
@@ -67,7 +68,8 @@
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -75,7 +77,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "array-find-index": {
@@ -89,7 +91,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -110,7 +112,7 @@
       "integrity": "sha1-mG43SfTRlExiU9eCSqgDXvsdsOQ=",
       "requires": {
         "buffer": "4.9.1",
-        "events": "^1.1.1",
+        "events": "1.1.1",
         "jmespath": "0.15.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
@@ -137,7 +139,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -151,9 +153,9 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "1.2.3",
+        "ieee754": "1.1.8",
+        "isarray": "1.0.0"
       }
     },
     "builtin-modules": {
@@ -167,7 +169,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "^0.2.0"
+        "callsites": "0.2.0"
       }
     },
     "callsites": {
@@ -186,8 +188,8 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       }
     },
     "cfn-stack-event-stream": {
@@ -195,20 +197,26 @@
       "resolved": "https://registry.npmjs.org/cfn-stack-event-stream/-/cfn-stack-event-stream-0.0.7.tgz",
       "integrity": "sha1-sfCiX5rd9cV60lszz+zXEBws2RE=",
       "requires": {
-        "aws-sdk": "^2.2.0"
+        "aws-sdk": "2.197.0"
       }
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
+    },
+    "chardet": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.5.0.tgz",
+      "integrity": "sha512-9ZTaoBaePSCFvNlNGrsyI8ZVACP2svUtq0DkM7t4K2ClAa96sqOIRjAzDTc8zXzFt1cZR46rRzLTiHFSJ+Qw0g=="
     },
     "circular-json": {
       "version": "0.3.3",
@@ -221,15 +229,16 @@
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
       "integrity": "sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=",
       "requires": {
-        "es5-ext": "0.8.x"
+        "es5-ext": "0.8.2"
       }
     },
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
       "requires": {
-        "restore-cursor": "^1.0.1"
+        "restore-cursor": "1.0.1"
       }
     },
     "cli-width": {
@@ -255,6 +264,19 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "color-convert": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "requires": {
+        "color-name": "1.1.1"
+      }
+    },
+    "color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+    },
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
@@ -270,10 +292,11 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.4",
+        "typedarray": "0.0.6"
       }
     },
     "core-js": {
@@ -284,7 +307,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cuid": {
       "version": "1.3.8",
@@ -292,7 +316,7 @@
       "integrity": "sha1-S4deCWm612T37AcGz0T1+wgx9rc=",
       "requires": {
         "browser-fingerprint": "0.0.1",
-        "core-js": "^1.1.1",
+        "core-js": "1.2.7",
         "node-fingerprint": "0.0.2"
       }
     },
@@ -301,7 +325,7 @@
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "d": {
@@ -310,7 +334,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.39"
       },
       "dependencies": {
         "es5-ext": {
@@ -319,8 +343,8 @@
           "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
           "dev": true,
           "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.1"
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1"
           }
         }
       }
@@ -362,7 +386,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "optional": true,
       "requires": {
-        "clone": "^1.0.2"
+        "clone": "1.0.3"
       }
     },
     "define-properties": {
@@ -371,8 +395,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
       }
     },
     "defined": {
@@ -387,13 +411,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
       }
     },
     "diff": {
@@ -406,7 +430,7 @@
       "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
       "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
       "requires": {
-        "heap": ">= 0.2.0"
+        "heap": "0.2.6"
       }
     },
     "doctrine": {
@@ -415,8 +439,8 @@
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "isarray": "^1.0.0"
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
       }
     },
     "dreamopt": {
@@ -424,7 +448,7 @@
       "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz",
       "integrity": "sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=",
       "requires": {
-        "wordwrap": ">=0.0.2"
+        "wordwrap": "1.0.0"
       }
     },
     "easy-table": {
@@ -432,8 +456,8 @@
       "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.1.1.tgz",
       "integrity": "sha512-C9Lvm0WFcn2RgxbMnTbXZenMIWcBtkzMr+dWqq/JsVoGFSVUVlPqeOa5LP5kM0I3zoOazFpckOEb2/0LDFfToQ==",
       "requires": {
-        "ansi-regex": "^3.0.0",
-        "wcwidth": ">=1.0.1"
+        "ansi-regex": "3.0.0",
+        "wcwidth": "1.0.1"
       }
     },
     "error-ex": {
@@ -441,7 +465,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es-abstract": {
@@ -450,11 +474,11 @@
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -463,9 +487,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "es5-ext": {
@@ -479,9 +503,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.39",
+        "es6-symbol": "3.1.1"
       },
       "dependencies": {
         "es5-ext": {
@@ -490,8 +514,8 @@
           "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
           "dev": true,
           "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.1"
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1"
           }
         }
       }
@@ -502,12 +526,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-set": "~0.1.5",
-        "es6-symbol": "~3.1.1",
-        "event-emitter": "~0.3.5"
+        "d": "1.0.0",
+        "es5-ext": "0.10.39",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
       },
       "dependencies": {
         "es5-ext": {
@@ -516,8 +540,8 @@
           "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
           "dev": true,
           "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.1"
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1"
           }
         }
       }
@@ -528,11 +552,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
+        "d": "1.0.0",
+        "es5-ext": "0.10.39",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
+        "event-emitter": "0.3.5"
       },
       "dependencies": {
         "es5-ext": {
@@ -541,8 +565,8 @@
           "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
           "dev": true,
           "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.1"
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1"
           }
         }
       }
@@ -553,8 +577,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.39"
       },
       "dependencies": {
         "es5-ext": {
@@ -563,8 +587,8 @@
           "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
           "dev": true,
           "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.1"
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1"
           }
         }
       }
@@ -575,10 +599,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.39",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       },
       "dependencies": {
         "es5-ext": {
@@ -587,8 +611,8 @@
           "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
           "dev": true,
           "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.1"
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1"
           }
         }
       }
@@ -604,10 +628,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "^0.1.3",
-        "es6-weak-map": "^2.0.1",
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
       }
     },
     "eslint": {
@@ -616,39 +640,39 @@
       "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "concat-stream": "^1.4.6",
-        "debug": "^2.1.1",
-        "doctrine": "^1.2.2",
-        "es6-map": "^0.1.3",
-        "escope": "^3.6.0",
-        "espree": "^3.1.6",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^1.1.1",
-        "glob": "^7.0.3",
-        "globals": "^9.2.0",
-        "ignore": "^3.1.2",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^0.12.0",
-        "is-my-json-valid": "^2.10.0",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.5.1",
-        "json-stable-stringify": "^1.0.0",
-        "levn": "^0.3.0",
-        "lodash": "^4.0.0",
-        "mkdirp": "^0.5.0",
-        "optionator": "^0.8.1",
-        "path-is-absolute": "^1.0.0",
-        "path-is-inside": "^1.0.1",
-        "pluralize": "^1.2.1",
-        "progress": "^1.1.8",
-        "require-uncached": "^1.0.2",
-        "shelljs": "^0.6.0",
-        "strip-json-comments": "~1.0.1",
-        "table": "^3.7.8",
-        "text-table": "~0.2.0",
-        "user-home": "^2.0.0"
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "es6-map": "0.1.5",
+        "escope": "3.6.0",
+        "espree": "3.5.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "1.3.1",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.17.2",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.10.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.5",
+        "mkdirp": "0.5.1",
+        "optionator": "0.8.2",
+        "path-is-absolute": "1.0.1",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.6.1",
+        "strip-json-comments": "1.0.4",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -663,8 +687,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         },
         "inquirer": {
@@ -673,19 +697,19 @@
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^1.1.0",
-            "ansi-regex": "^2.0.0",
-            "chalk": "^1.0.0",
-            "cli-cursor": "^1.0.1",
-            "cli-width": "^2.0.0",
-            "figures": "^1.3.5",
-            "lodash": "^4.3.0",
-            "readline2": "^1.0.1",
-            "run-async": "^0.1.0",
-            "rx-lite": "^3.1.2",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.0",
-            "through": "^2.3.6"
+            "ansi-escapes": "1.4.0",
+            "ansi-regex": "2.1.1",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "2.2.0",
+            "figures": "1.7.0",
+            "lodash": "4.17.5",
+            "readline2": "1.0.1",
+            "run-async": "0.1.0",
+            "rx-lite": "3.1.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
           }
         },
         "is-fullwidth-code-point": {
@@ -694,7 +718,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "run-async": {
@@ -703,7 +727,7 @@
           "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
           "dev": true,
           "requires": {
-            "once": "^1.3.0"
+            "once": "1.4.0"
           }
         },
         "string-width": {
@@ -712,9 +736,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -725,8 +749,8 @@
       "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
       "dev": true,
       "requires": {
-        "acorn": "^5.4.0",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "5.4.1",
+        "acorn-jsx": "3.0.1"
       }
     },
     "esprima": {
@@ -741,8 +765,8 @@
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0",
-        "object-assign": "^4.0.1"
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
       }
     },
     "estraverse": {
@@ -763,8 +787,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.39"
       },
       "dependencies": {
         "es5-ext": {
@@ -773,8 +797,8 @@
           "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
           "dev": true,
           "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.1"
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.1"
           }
         }
       }
@@ -787,22 +811,8 @@
     "exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
-    },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-    },
-    "external-editor": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
-      "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
-      "requires": {
-        "extend": "^3.0.0",
-        "spawn-sync": "^1.0.15",
-        "tmp": "^0.0.29"
-      }
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -820,7 +830,7 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -829,8 +839,8 @@
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       }
     },
     "find-up": {
@@ -838,8 +848,8 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "flat-cache": {
@@ -848,10 +858,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       }
     },
     "for-each": {
@@ -860,7 +870,7 @@
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
       "dev": true,
       "requires": {
-        "is-function": "~1.0.0"
+        "is-function": "1.0.1"
       }
     },
     "foreach": {
@@ -875,7 +885,7 @@
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "~1.1"
+        "samsam": "1.1.2"
       }
     },
     "fs.realpath": {
@@ -902,7 +912,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "^1.0.0"
+        "is-property": "1.0.2"
       }
     },
     "get-stdin": {
@@ -916,12 +926,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "globals": {
@@ -936,12 +946,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "graceful-fs": {
@@ -955,23 +965,30 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         }
       }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "heap": {
       "version": "0.2.6",
@@ -982,6 +999,14 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
     },
     "ieee754": {
       "version": "1.1.8",
@@ -1005,7 +1030,7 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "inflight": {
@@ -1014,34 +1039,123 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "inquirer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-2.0.0.tgz",
-      "integrity": "sha1-4TUWh7kNFQykA86qPO+x4wZb70s=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.1.0.tgz",
+      "integrity": "sha512-f9K2MMx/G/AVmJSaZg2a+GVLRRmTdlGLbwxsibNd6yNTxXujqxPypjCnxnC0y4+Wb/rNY5KyKuq06AO5jrE+7w==",
       "requires": {
-        "ansi-escapes": "^1.1.0",
-        "chalk": "^1.0.0",
-        "cli-cursor": "^1.0.1",
-        "cli-width": "^2.0.0",
-        "external-editor": "^1.1.0",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
-        "mute-stream": "0.0.6",
-        "pinkie-promise": "^2.0.0",
-        "run-async": "^2.2.0",
-        "rx": "^4.1.0",
-        "string-width": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "through": "^2.3.6"
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "3.0.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.5",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rxjs": "6.2.2",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "1.9.2"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "requires": {
+            "restore-cursor": "2.0.0"
+          }
+        },
+        "external-editor": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.0.tgz",
+          "integrity": "sha512-mpkfj0FEdxrIhOC04zk85X7StNtr0yXnG7zCb+8ikO8OJi2jsHh5YGoknNTyXgsbHOf1WOOcVU3kPFWT2WgCkQ==",
+          "requires": {
+            "chardet": "0.5.0",
+            "iconv-lite": "0.4.23",
+            "tmp": "0.0.33"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "requires": {
+            "mimic-fn": "1.2.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "requires": {
+            "onetime": "2.0.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "requires": {
+            "os-tmpdir": "1.0.2"
+          }
+        }
       }
     },
     "is-arrayish": {
@@ -1054,7 +1168,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-callable": {
@@ -1074,7 +1188,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -1100,11 +1214,11 @@
       "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "dev": true,
       "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
       }
     },
     "is-path-cwd": {
@@ -1119,7 +1233,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -1128,7 +1242,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-promise": {
@@ -1148,7 +1262,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.1"
       }
     },
     "is-resolvable": {
@@ -1184,8 +1298,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
       }
     },
     "json-diff": {
@@ -1193,9 +1307,9 @@
       "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.3.1.tgz",
       "integrity": "sha1-bbw64tJeB1p/1xvNmHRFhmb7aBs=",
       "requires": {
-        "cli-color": "~0.1.6",
-        "difflib": "~0.2.1",
-        "dreamopt": "~0.6.0"
+        "cli-color": "0.1.7",
+        "difflib": "0.2.4",
+        "dreamopt": "0.6.0"
       }
     },
     "json-stable-stringify": {
@@ -1203,7 +1317,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "jsonify": {
@@ -1223,8 +1337,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "load-json-file": {
@@ -1232,11 +1346,11 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       }
     },
     "lodash": {
@@ -1255,8 +1369,8 @@
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "map-obj": {
@@ -1269,17 +1383,22 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1287,7 +1406,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -1318,11 +1437,6 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "mute-stream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-      "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
-    },
     "node-fingerprint": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/node-fingerprint/-/node-fingerprint-0.0.2.tgz",
@@ -1333,10 +1447,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.1"
       }
     },
     "number-is-nan": {
@@ -1350,27 +1464,27 @@
       "integrity": "sha1-L2AUYQpXBwAhxMBn6bnjMKI6xqc=",
       "dev": true,
       "requires": {
-        "append-transform": "^0.4.0",
-        "arrify": "^1.0.1",
-        "caching-transform": "^1.0.0",
-        "convert-source-map": "^1.1.2",
-        "default-require-extensions": "^1.0.0",
-        "find-cache-dir": "^0.1.1",
-        "find-up": "^1.1.2",
-        "foreground-child": "^1.5.1",
-        "glob": "^7.0.3",
-        "istanbul": "^0.4.3",
-        "md5-hex": "^1.2.0",
-        "micromatch": "^2.3.7",
-        "mkdirp": "^0.5.0",
-        "pkg-up": "^1.0.0",
-        "resolve-from": "^2.0.0",
-        "rimraf": "^2.5.0",
-        "signal-exit": "^3.0.0",
-        "source-map": "^0.5.3",
-        "spawn-wrap": "^1.2.2",
-        "test-exclude": "^1.1.0",
-        "yargs": "^4.7.0"
+        "append-transform": "0.4.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.2.0",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "1.1.2",
+        "foreground-child": "1.5.1",
+        "glob": "7.0.3",
+        "istanbul": "0.4.3",
+        "md5-hex": "1.3.0",
+        "micromatch": "2.3.8",
+        "mkdirp": "0.5.1",
+        "pkg-up": "1.0.0",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.5.2",
+        "signal-exit": "3.0.0",
+        "source-map": "0.5.6",
+        "spawn-wrap": "1.2.3",
+        "test-exclude": "1.1.0",
+        "yargs": "4.7.1"
       },
       "dependencies": {
         "append-transform": {
@@ -1379,7 +1493,7 @@
           "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
           "dev": true,
           "requires": {
-            "default-require-extensions": "^1.0.0"
+            "default-require-extensions": "1.0.0"
           }
         },
         "arrify": {
@@ -1394,9 +1508,9 @@
           "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
           "dev": true,
           "requires": {
-            "md5-hex": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "write-file-atomic": "^1.1.4"
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.1.4"
           },
           "dependencies": {
             "write-file-atomic": {
@@ -1405,9 +1519,9 @@
               "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
               "dev": true,
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "imurmurhash": "^0.1.4",
-                "slide": "^1.1.5"
+                "graceful-fs": "4.1.4",
+                "imurmurhash": "0.1.4",
+                "slide": "1.1.6"
               },
               "dependencies": {
                 "graceful-fs": {
@@ -1444,7 +1558,7 @@
           "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
           "dev": true,
           "requires": {
-            "strip-bom": "^2.0.0"
+            "strip-bom": "2.0.0"
           },
           "dependencies": {
             "strip-bom": {
@@ -1453,7 +1567,7 @@
               "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
               "dev": true,
               "requires": {
-                "is-utf8": "^0.2.0"
+                "is-utf8": "0.2.1"
               },
               "dependencies": {
                 "is-utf8": {
@@ -1472,9 +1586,9 @@
           "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
-            "commondir": "^1.0.1",
-            "mkdirp": "^0.5.1",
-            "pkg-dir": "^1.0.0"
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
           },
           "dependencies": {
             "commondir": {
@@ -1489,7 +1603,7 @@
               "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
               "dev": true,
               "requires": {
-                "find-up": "^1.0.0"
+                "find-up": "1.1.2"
               }
             }
           }
@@ -1500,8 +1614,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           },
           "dependencies": {
             "path-exists": {
@@ -1510,7 +1624,7 @@
               "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
               "dev": true,
               "requires": {
-                "pinkie-promise": "^2.0.0"
+                "pinkie-promise": "2.0.1"
               }
             },
             "pinkie-promise": {
@@ -1519,7 +1633,7 @@
               "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
               "dev": true,
               "requires": {
-                "pinkie": "^2.0.0"
+                "pinkie": "2.0.4"
               },
               "dependencies": {
                 "pinkie": {
@@ -1538,9 +1652,9 @@
           "integrity": "sha1-76NNl4DSV8dQsR4pbi4e3BT/+qo=",
           "dev": true,
           "requires": {
-            "cross-spawn-async": "^2.1.1",
-            "signal-exit": "^2.0.0",
-            "which": "^1.2.1"
+            "cross-spawn-async": "2.2.4",
+            "signal-exit": "2.1.2",
+            "which": "1.2.10"
           },
           "dependencies": {
             "cross-spawn-async": {
@@ -1549,8 +1663,8 @@
               "integrity": "sha1-yajY6aBlAsekYpbjOhoFS10vGBI=",
               "dev": true,
               "requires": {
-                "lru-cache": "^4.0.0",
-                "which": "^1.2.8"
+                "lru-cache": "4.0.1",
+                "which": "1.2.10"
               },
               "dependencies": {
                 "lru-cache": {
@@ -1559,8 +1673,8 @@
                   "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
                   "dev": true,
                   "requires": {
-                    "pseudomap": "^1.0.1",
-                    "yallist": "^2.0.0"
+                    "pseudomap": "1.0.2",
+                    "yallist": "2.0.0"
                   },
                   "dependencies": {
                     "pseudomap": {
@@ -1591,7 +1705,7 @@
               "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
               "dev": true,
               "requires": {
-                "isexe": "^1.1.1"
+                "isexe": "1.1.2"
               },
               "dependencies": {
                 "isexe": {
@@ -1610,11 +1724,11 @@
           "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.5",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.0",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.0"
           },
           "dependencies": {
             "inflight": {
@@ -1623,8 +1737,8 @@
               "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
               "dev": true,
               "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.3.3",
+                "wrappy": "1.0.2"
               },
               "dependencies": {
                 "wrappy": {
@@ -1647,7 +1761,7 @@
               "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
               "dev": true,
               "requires": {
-                "brace-expansion": "^1.0.0"
+                "brace-expansion": "1.1.4"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -1656,7 +1770,7 @@
                   "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
                   "dev": true,
                   "requires": {
-                    "balanced-match": "^0.4.1",
+                    "balanced-match": "0.4.1",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -1682,7 +1796,7 @@
               "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
               "dev": true,
               "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
               },
               "dependencies": {
                 "wrappy": {
@@ -1707,20 +1821,20 @@
           "integrity": "sha1-W3FO4K5JOsXvIEuZ84crzu9z1To=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.x",
-            "async": "1.x",
-            "escodegen": "1.8.x",
-            "esprima": "2.7.x",
-            "fileset": "0.2.x",
-            "handlebars": "^4.0.1",
-            "js-yaml": "3.x",
-            "mkdirp": "0.5.x",
-            "nopt": "3.x",
-            "once": "1.x",
-            "resolve": "1.1.x",
-            "supports-color": "^3.1.0",
-            "which": "^1.1.1",
-            "wordwrap": "^1.0.0"
+            "abbrev": "1.0.7",
+            "async": "1.5.2",
+            "escodegen": "1.8.0",
+            "esprima": "2.7.2",
+            "fileset": "0.2.1",
+            "handlebars": "4.0.5",
+            "js-yaml": "3.6.1",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "once": "1.3.3",
+            "resolve": "1.1.7",
+            "supports-color": "3.1.2",
+            "which": "1.2.10",
+            "wordwrap": "1.0.0"
           },
           "dependencies": {
             "abbrev": {
@@ -1741,11 +1855,11 @@
               "integrity": "sha1-skaq6CnOc9WeLFVyc1nt0cEwqBs=",
               "dev": true,
               "requires": {
-                "esprima": "^2.7.1",
-                "estraverse": "^1.9.1",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.2.0"
+                "esprima": "2.7.2",
+                "estraverse": "1.9.3",
+                "esutils": "2.0.2",
+                "optionator": "0.8.1",
+                "source-map": "0.2.0"
               },
               "dependencies": {
                 "estraverse": {
@@ -1766,12 +1880,12 @@
                   "integrity": "sha1-4xtJMs3V+4Yqiw0QvGPT7h7H14s=",
                   "dev": true,
                   "requires": {
-                    "deep-is": "~0.1.3",
-                    "fast-levenshtein": "^1.1.0",
-                    "levn": "~0.3.0",
-                    "prelude-ls": "~1.1.2",
-                    "type-check": "~0.3.2",
-                    "wordwrap": "~1.0.0"
+                    "deep-is": "0.1.3",
+                    "fast-levenshtein": "1.1.3",
+                    "levn": "0.3.0",
+                    "prelude-ls": "1.1.2",
+                    "type-check": "0.3.2",
+                    "wordwrap": "1.0.0"
                   },
                   "dependencies": {
                     "deep-is": {
@@ -1792,8 +1906,8 @@
                       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
                       "dev": true,
                       "requires": {
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2"
+                        "prelude-ls": "1.1.2",
+                        "type-check": "0.3.2"
                       }
                     },
                     "prelude-ls": {
@@ -1808,7 +1922,7 @@
                       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
                       "dev": true,
                       "requires": {
-                        "prelude-ls": "~1.1.2"
+                        "prelude-ls": "1.1.2"
                       }
                     }
                   }
@@ -1820,7 +1934,7 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "amdefine": ">=0.0.4"
+                    "amdefine": "1.0.0"
                   },
                   "dependencies": {
                     "amdefine": {
@@ -1846,8 +1960,8 @@
               "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
               "dev": true,
               "requires": {
-                "glob": "5.x",
-                "minimatch": "2.x"
+                "glob": "5.0.15",
+                "minimatch": "2.0.10"
               },
               "dependencies": {
                 "glob": {
@@ -1856,11 +1970,11 @@
                   "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                   "dev": true,
                   "requires": {
-                    "inflight": "^1.0.4",
-                    "inherits": "2",
-                    "minimatch": "2 || 3",
-                    "once": "^1.3.0",
-                    "path-is-absolute": "^1.0.0"
+                    "inflight": "1.0.5",
+                    "inherits": "2.0.1",
+                    "minimatch": "2.0.10",
+                    "once": "1.3.3",
+                    "path-is-absolute": "1.0.0"
                   },
                   "dependencies": {
                     "inflight": {
@@ -1869,8 +1983,8 @@
                       "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
                       "dev": true,
                       "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.3.3",
+                        "wrappy": "1.0.2"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -1901,7 +2015,7 @@
                   "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "^1.0.0"
+                    "brace-expansion": "1.1.4"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -1910,7 +2024,7 @@
                       "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
                       "dev": true,
                       "requires": {
-                        "balanced-match": "^0.4.1",
+                        "balanced-match": "0.4.1",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -1938,10 +2052,10 @@
               "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
               "dev": true,
               "requires": {
-                "async": "^1.4.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.4.4",
-                "uglify-js": "^2.6"
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.6.2"
               },
               "dependencies": {
                 "optimist": {
@@ -1950,8 +2064,8 @@
                   "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
                   "dev": true,
                   "requires": {
-                    "minimist": "~0.0.1",
-                    "wordwrap": "~0.0.2"
+                    "minimist": "0.0.10",
+                    "wordwrap": "0.0.3"
                   },
                   "dependencies": {
                     "minimist": {
@@ -1974,7 +2088,7 @@
                   "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                   "dev": true,
                   "requires": {
-                    "amdefine": ">=0.0.4"
+                    "amdefine": "1.0.0"
                   },
                   "dependencies": {
                     "amdefine": {
@@ -1992,10 +2106,10 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "async": "~0.2.6",
-                    "source-map": "~0.5.1",
-                    "uglify-to-browserify": "~1.0.0",
-                    "yargs": "~3.10.0"
+                    "async": "0.2.10",
+                    "source-map": "0.5.6",
+                    "uglify-to-browserify": "1.0.2",
+                    "yargs": "3.10.0"
                   },
                   "dependencies": {
                     "async": {
@@ -2026,9 +2140,9 @@
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "camelcase": "^1.0.2",
-                        "cliui": "^2.1.0",
-                        "decamelize": "^1.0.0",
+                        "camelcase": "1.2.1",
+                        "cliui": "2.1.0",
+                        "decamelize": "1.2.0",
                         "window-size": "0.1.0"
                       },
                       "dependencies": {
@@ -2046,8 +2160,8 @@
                           "dev": true,
                           "optional": true,
                           "requires": {
-                            "center-align": "^0.1.1",
-                            "right-align": "^0.1.1",
+                            "center-align": "0.1.3",
+                            "right-align": "0.1.3",
                             "wordwrap": "0.0.2"
                           },
                           "dependencies": {
@@ -2058,8 +2172,8 @@
                               "dev": true,
                               "optional": true,
                               "requires": {
-                                "align-text": "^0.1.3",
-                                "lazy-cache": "^1.0.3"
+                                "align-text": "0.1.4",
+                                "lazy-cache": "1.0.4"
                               },
                               "dependencies": {
                                 "align-text": {
@@ -2069,9 +2183,9 @@
                                   "dev": true,
                                   "optional": true,
                                   "requires": {
-                                    "kind-of": "^3.0.2",
-                                    "longest": "^1.0.1",
-                                    "repeat-string": "^1.5.2"
+                                    "kind-of": "3.0.3",
+                                    "longest": "1.0.1",
+                                    "repeat-string": "1.5.4"
                                   },
                                   "dependencies": {
                                     "kind-of": {
@@ -2081,7 +2195,7 @@
                                       "dev": true,
                                       "optional": true,
                                       "requires": {
-                                        "is-buffer": "^1.0.2"
+                                        "is-buffer": "1.1.3"
                                       },
                                       "dependencies": {
                                         "is-buffer": {
@@ -2125,7 +2239,7 @@
                               "dev": true,
                               "optional": true,
                               "requires": {
-                                "align-text": "^0.1.1"
+                                "align-text": "0.1.4"
                               },
                               "dependencies": {
                                 "align-text": {
@@ -2135,9 +2249,9 @@
                                   "dev": true,
                                   "optional": true,
                                   "requires": {
-                                    "kind-of": "^3.0.2",
-                                    "longest": "^1.0.1",
-                                    "repeat-string": "^1.5.2"
+                                    "kind-of": "3.0.3",
+                                    "longest": "1.0.1",
+                                    "repeat-string": "1.5.4"
                                   },
                                   "dependencies": {
                                     "kind-of": {
@@ -2147,7 +2261,7 @@
                                       "dev": true,
                                       "optional": true,
                                       "requires": {
-                                        "is-buffer": "^1.0.2"
+                                        "is-buffer": "1.1.3"
                                       },
                                       "dependencies": {
                                         "is-buffer": {
@@ -2212,8 +2326,8 @@
               "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
               "dev": true,
               "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^2.6.0"
+                "argparse": "1.0.7",
+                "esprima": "2.7.2"
               },
               "dependencies": {
                 "argparse": {
@@ -2222,7 +2336,7 @@
                   "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE=",
                   "dev": true,
                   "requires": {
-                    "sprintf-js": "~1.0.2"
+                    "sprintf-js": "1.0.3"
                   },
                   "dependencies": {
                     "sprintf-js": {
@@ -2241,7 +2355,7 @@
               "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
               "dev": true,
               "requires": {
-                "abbrev": "1"
+                "abbrev": "1.0.7"
               }
             },
             "once": {
@@ -2250,7 +2364,7 @@
               "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
               "dev": true,
               "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
               },
               "dependencies": {
                 "wrappy": {
@@ -2273,7 +2387,7 @@
               "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
               "dev": true,
               "requires": {
-                "has-flag": "^1.0.0"
+                "has-flag": "1.0.0"
               },
               "dependencies": {
                 "has-flag": {
@@ -2290,7 +2404,7 @@
               "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
               "dev": true,
               "requires": {
-                "isexe": "^1.1.1"
+                "isexe": "1.1.2"
               },
               "dependencies": {
                 "isexe": {
@@ -2315,7 +2429,7 @@
           "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
-            "md5-o-matic": "^0.1.1"
+            "md5-o-matic": "0.1.1"
           },
           "dependencies": {
             "md5-o-matic": {
@@ -2332,19 +2446,19 @@
           "integrity": "sha1-lPv4837Z7eyga/HI97dD+19vWFQ=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.0",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.0.3",
+            "normalize-path": "2.0.1",
+            "object.omit": "2.0.0",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.3"
           },
           "dependencies": {
             "arr-diff": {
@@ -2353,7 +2467,7 @@
               "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
               "dev": true,
               "requires": {
-                "arr-flatten": "^1.0.1"
+                "arr-flatten": "1.0.1"
               },
               "dependencies": {
                 "arr-flatten": {
@@ -2376,9 +2490,9 @@
               "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
               "dev": true,
               "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
               },
               "dependencies": {
                 "expand-range": {
@@ -2387,7 +2501,7 @@
                   "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
                   "dev": true,
                   "requires": {
-                    "fill-range": "^2.1.0"
+                    "fill-range": "2.2.3"
                   },
                   "dependencies": {
                     "fill-range": {
@@ -2396,11 +2510,11 @@
                       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
                       "dev": true,
                       "requires": {
-                        "is-number": "^2.1.0",
-                        "isobject": "^2.0.0",
-                        "randomatic": "^1.1.3",
-                        "repeat-element": "^1.1.2",
-                        "repeat-string": "^1.5.2"
+                        "is-number": "2.1.0",
+                        "isobject": "2.1.0",
+                        "randomatic": "1.1.5",
+                        "repeat-element": "1.1.2",
+                        "repeat-string": "1.5.4"
                       },
                       "dependencies": {
                         "is-number": {
@@ -2409,7 +2523,7 @@
                           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
                           "dev": true,
                           "requires": {
-                            "kind-of": "^3.0.2"
+                            "kind-of": "3.0.3"
                           }
                         },
                         "isobject": {
@@ -2435,8 +2549,8 @@
                           "integrity": "sha1-Xp718tVzxnvSuBJK6QtRVuRXhAs=",
                           "dev": true,
                           "requires": {
-                            "is-number": "^2.0.2",
-                            "kind-of": "^3.0.2"
+                            "is-number": "2.1.0",
+                            "kind-of": "3.0.3"
                           }
                         },
                         "repeat-string": {
@@ -2469,7 +2583,7 @@
               "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
               "dev": true,
               "requires": {
-                "is-posix-bracket": "^0.1.0"
+                "is-posix-bracket": "0.1.1"
               },
               "dependencies": {
                 "is-posix-bracket": {
@@ -2486,7 +2600,7 @@
               "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
               "dev": true,
               "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
               }
             },
             "filename-regex": {
@@ -2507,7 +2621,7 @@
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
               }
             },
             "kind-of": {
@@ -2516,7 +2630,7 @@
               "integrity": "sha1-xhYIdH2BWwNiVW2zJ2Nip6OK3tM=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.0.2"
+                "is-buffer": "1.1.3"
               },
               "dependencies": {
                 "is-buffer": {
@@ -2539,8 +2653,8 @@
               "integrity": "sha1-hoWXMz1U5gZilAu0WGBd1q4S/pQ=",
               "dev": true,
               "requires": {
-                "for-own": "^0.1.3",
-                "is-extendable": "^0.1.1"
+                "for-own": "0.1.4",
+                "is-extendable": "0.1.1"
               },
               "dependencies": {
                 "for-own": {
@@ -2549,7 +2663,7 @@
                   "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
                   "dev": true,
                   "requires": {
-                    "for-in": "^0.1.5"
+                    "for-in": "0.1.5"
                   },
                   "dependencies": {
                     "for-in": {
@@ -2574,10 +2688,10 @@
               "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
               "dev": true,
               "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.2",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
               },
               "dependencies": {
                 "glob-base": {
@@ -2586,8 +2700,8 @@
                   "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
                   "dev": true,
                   "requires": {
-                    "glob-parent": "^2.0.0",
-                    "is-glob": "^2.0.0"
+                    "glob-parent": "2.0.0",
+                    "is-glob": "2.0.1"
                   },
                   "dependencies": {
                     "glob-parent": {
@@ -2596,7 +2710,7 @@
                       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                       "dev": true,
                       "requires": {
-                        "is-glob": "^2.0.0"
+                        "is-glob": "2.0.1"
                       }
                     }
                   }
@@ -2615,8 +2729,8 @@
               "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
               "dev": true,
               "requires": {
-                "is-equal-shallow": "^0.1.3",
-                "is-primitive": "^2.0.0"
+                "is-equal-shallow": "0.1.3",
+                "is-primitive": "2.0.0"
               },
               "dependencies": {
                 "is-equal-shallow": {
@@ -2625,7 +2739,7 @@
                   "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
                   "dev": true,
                   "requires": {
-                    "is-primitive": "^2.0.0"
+                    "is-primitive": "2.0.0"
                   }
                 },
                 "is-primitive": {
@@ -2661,7 +2775,7 @@
           "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0"
+            "find-up": "1.1.2"
           }
         },
         "resolve-from": {
@@ -2676,7 +2790,7 @@
           "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
           "dev": true,
           "requires": {
-            "glob": "^7.0.0"
+            "glob": "7.0.3"
           }
         },
         "signal-exit": {
@@ -2697,12 +2811,12 @@
           "integrity": "sha1-3300R/tKAZYZpB9o7mQqcY5gYuk=",
           "dev": true,
           "requires": {
-            "foreground-child": "^1.3.3",
-            "mkdirp": "^0.5.0",
-            "os-homedir": "^1.0.1",
-            "rimraf": "^2.3.3",
-            "signal-exit": "^2.0.0",
-            "which": "^1.2.4"
+            "foreground-child": "1.5.1",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.1",
+            "rimraf": "2.5.2",
+            "signal-exit": "2.1.2",
+            "which": "1.2.10"
           },
           "dependencies": {
             "os-homedir": {
@@ -2723,7 +2837,7 @@
               "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
               "dev": true,
               "requires": {
-                "isexe": "^1.1.1"
+                "isexe": "1.1.2"
               },
               "dependencies": {
                 "isexe": {
@@ -2742,11 +2856,11 @@
           "integrity": "sha1-9d3XGJJ7Ev0C8nCgqpOc627qQVE=",
           "dev": true,
           "requires": {
-            "arrify": "^1.0.1",
-            "lodash.assign": "^4.0.9",
-            "micromatch": "^2.3.8",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1"
+            "arrify": "1.0.1",
+            "lodash.assign": "4.0.9",
+            "micromatch": "2.3.8",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
           },
           "dependencies": {
             "lodash.assign": {
@@ -2755,8 +2869,8 @@
               "integrity": "sha1-Cgcx2TWQ3dm6RYn61lqvbuCSF+M=",
               "dev": true,
               "requires": {
-                "lodash.keys": "^4.0.0",
-                "lodash.rest": "^4.0.0"
+                "lodash.keys": "4.0.7",
+                "lodash.rest": "4.0.3"
               },
               "dependencies": {
                 "lodash.keys": {
@@ -2779,8 +2893,8 @@
               "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
               "dev": true,
               "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
               },
               "dependencies": {
                 "read-pkg": {
@@ -2789,9 +2903,9 @@
                   "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                   "dev": true,
                   "requires": {
-                    "load-json-file": "^1.0.0",
-                    "normalize-package-data": "^2.3.2",
-                    "path-type": "^1.0.0"
+                    "load-json-file": "1.1.0",
+                    "normalize-package-data": "2.3.5",
+                    "path-type": "1.1.0"
                   },
                   "dependencies": {
                     "load-json-file": {
@@ -2800,11 +2914,11 @@
                       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                       "dev": true,
                       "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0",
-                        "strip-bom": "^2.0.0"
+                        "graceful-fs": "4.1.4",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
                       },
                       "dependencies": {
                         "graceful-fs": {
@@ -2819,7 +2933,7 @@
                           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                           "dev": true,
                           "requires": {
-                            "error-ex": "^1.2.0"
+                            "error-ex": "1.3.0"
                           },
                           "dependencies": {
                             "error-ex": {
@@ -2828,7 +2942,7 @@
                               "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
                               "dev": true,
                               "requires": {
-                                "is-arrayish": "^0.2.1"
+                                "is-arrayish": "0.2.1"
                               },
                               "dependencies": {
                                 "is-arrayish": {
@@ -2853,7 +2967,7 @@
                           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                           "dev": true,
                           "requires": {
-                            "pinkie": "^2.0.0"
+                            "pinkie": "2.0.4"
                           },
                           "dependencies": {
                             "pinkie": {
@@ -2870,7 +2984,7 @@
                           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                           "dev": true,
                           "requires": {
-                            "is-utf8": "^0.2.0"
+                            "is-utf8": "0.2.1"
                           },
                           "dependencies": {
                             "is-utf8": {
@@ -2889,10 +3003,10 @@
                       "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
                       "dev": true,
                       "requires": {
-                        "hosted-git-info": "^2.1.4",
-                        "is-builtin-module": "^1.0.0",
-                        "semver": "2 || 3 || 4 || 5",
-                        "validate-npm-package-license": "^3.0.1"
+                        "hosted-git-info": "2.1.5",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.1.0",
+                        "validate-npm-package-license": "3.0.1"
                       },
                       "dependencies": {
                         "hosted-git-info": {
@@ -2907,7 +3021,7 @@
                           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                           "dev": true,
                           "requires": {
-                            "builtin-modules": "^1.0.0"
+                            "builtin-modules": "1.1.1"
                           },
                           "dependencies": {
                             "builtin-modules": {
@@ -2930,8 +3044,8 @@
                           "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
                           "dev": true,
                           "requires": {
-                            "spdx-correct": "~1.0.0",
-                            "spdx-expression-parse": "~1.0.0"
+                            "spdx-correct": "1.0.2",
+                            "spdx-expression-parse": "1.0.2"
                           },
                           "dependencies": {
                             "spdx-correct": {
@@ -2940,7 +3054,7 @@
                               "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                               "dev": true,
                               "requires": {
-                                "spdx-license-ids": "^1.0.2"
+                                "spdx-license-ids": "1.2.1"
                               },
                               "dependencies": {
                                 "spdx-license-ids": {
@@ -2957,8 +3071,8 @@
                               "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
                               "dev": true,
                               "requires": {
-                                "spdx-exceptions": "^1.0.4",
-                                "spdx-license-ids": "^1.0.0"
+                                "spdx-exceptions": "1.0.4",
+                                "spdx-license-ids": "1.2.1"
                               },
                               "dependencies": {
                                 "spdx-exceptions": {
@@ -2985,9 +3099,9 @@
                       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                       "dev": true,
                       "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "graceful-fs": "4.1.4",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
                       },
                       "dependencies": {
                         "graceful-fs": {
@@ -3008,7 +3122,7 @@
                           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                           "dev": true,
                           "requires": {
-                            "pinkie": "^2.0.0"
+                            "pinkie": "2.0.4"
                           },
                           "dependencies": {
                             "pinkie": {
@@ -3039,19 +3153,19 @@
           "integrity": "sha1-5gQyZYozh/8mnAKOrN5KUS5Djf8=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "lodash.assign": "^4.0.3",
-            "os-locale": "^1.4.0",
-            "pkg-conf": "^1.1.2",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^1.0.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^2.4.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "lodash.assign": "4.0.9",
+            "os-locale": "1.4.0",
+            "pkg-conf": "1.1.3",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "1.0.0",
+            "string-width": "1.0.1",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.0"
           },
           "dependencies": {
             "camelcase": {
@@ -3066,9 +3180,9 @@
               "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
               "dev": true,
               "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "1.0.1",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.0.0"
               },
               "dependencies": {
                 "strip-ansi": {
@@ -3077,7 +3191,7 @@
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "^2.0.0"
+                    "ansi-regex": "2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -3094,7 +3208,7 @@
                   "integrity": "sha1-fTD4+HP5pbvDpk2ryNF34HGuQm8=",
                   "dev": true,
                   "requires": {
-                    "string-width": "^1.0.1"
+                    "string-width": "1.0.1"
                   }
                 }
               }
@@ -3111,8 +3225,8 @@
               "integrity": "sha1-Cgcx2TWQ3dm6RYn61lqvbuCSF+M=",
               "dev": true,
               "requires": {
-                "lodash.keys": "^4.0.0",
-                "lodash.rest": "^4.0.0"
+                "lodash.keys": "4.0.7",
+                "lodash.rest": "4.0.3"
               },
               "dependencies": {
                 "lodash.keys": {
@@ -3135,7 +3249,7 @@
               "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
               "dev": true,
               "requires": {
-                "lcid": "^1.0.0"
+                "lcid": "1.0.0"
               },
               "dependencies": {
                 "lcid": {
@@ -3144,7 +3258,7 @@
                   "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                   "dev": true,
                   "requires": {
-                    "invert-kv": "^1.0.0"
+                    "invert-kv": "1.0.0"
                   },
                   "dependencies": {
                     "invert-kv": {
@@ -3163,10 +3277,10 @@
               "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
               "dev": true,
               "requires": {
-                "find-up": "^1.0.0",
-                "load-json-file": "^1.1.0",
-                "object-assign": "^4.0.1",
-                "symbol": "^0.2.1"
+                "find-up": "1.1.2",
+                "load-json-file": "1.1.0",
+                "object-assign": "4.1.0",
+                "symbol": "0.2.3"
               },
               "dependencies": {
                 "load-json-file": {
@@ -3175,11 +3289,11 @@
                   "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "^4.1.2",
-                    "parse-json": "^2.2.0",
-                    "pify": "^2.0.0",
-                    "pinkie-promise": "^2.0.0",
-                    "strip-bom": "^2.0.0"
+                    "graceful-fs": "4.1.4",
+                    "parse-json": "2.2.0",
+                    "pify": "2.3.0",
+                    "pinkie-promise": "2.0.1",
+                    "strip-bom": "2.0.0"
                   },
                   "dependencies": {
                     "graceful-fs": {
@@ -3194,7 +3308,7 @@
                       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                       "dev": true,
                       "requires": {
-                        "error-ex": "^1.2.0"
+                        "error-ex": "1.3.0"
                       },
                       "dependencies": {
                         "error-ex": {
@@ -3203,7 +3317,7 @@
                           "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
                           "dev": true,
                           "requires": {
-                            "is-arrayish": "^0.2.1"
+                            "is-arrayish": "0.2.1"
                           },
                           "dependencies": {
                             "is-arrayish": {
@@ -3228,7 +3342,7 @@
                       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                       "dev": true,
                       "requires": {
-                        "pinkie": "^2.0.0"
+                        "pinkie": "2.0.4"
                       },
                       "dependencies": {
                         "pinkie": {
@@ -3245,7 +3359,7 @@
                       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                       "dev": true,
                       "requires": {
-                        "is-utf8": "^0.2.0"
+                        "is-utf8": "0.2.1"
                       },
                       "dependencies": {
                         "is-utf8": {
@@ -3278,8 +3392,8 @@
               "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
               "dev": true,
               "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
               },
               "dependencies": {
                 "read-pkg": {
@@ -3288,9 +3402,9 @@
                   "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                   "dev": true,
                   "requires": {
-                    "load-json-file": "^1.0.0",
-                    "normalize-package-data": "^2.3.2",
-                    "path-type": "^1.0.0"
+                    "load-json-file": "1.1.0",
+                    "normalize-package-data": "2.3.5",
+                    "path-type": "1.1.0"
                   },
                   "dependencies": {
                     "load-json-file": {
@@ -3299,11 +3413,11 @@
                       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                       "dev": true,
                       "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0",
-                        "strip-bom": "^2.0.0"
+                        "graceful-fs": "4.1.4",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
                       },
                       "dependencies": {
                         "graceful-fs": {
@@ -3318,7 +3432,7 @@
                           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                           "dev": true,
                           "requires": {
-                            "error-ex": "^1.2.0"
+                            "error-ex": "1.3.0"
                           },
                           "dependencies": {
                             "error-ex": {
@@ -3327,7 +3441,7 @@
                               "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
                               "dev": true,
                               "requires": {
-                                "is-arrayish": "^0.2.1"
+                                "is-arrayish": "0.2.1"
                               },
                               "dependencies": {
                                 "is-arrayish": {
@@ -3352,7 +3466,7 @@
                           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                           "dev": true,
                           "requires": {
-                            "pinkie": "^2.0.0"
+                            "pinkie": "2.0.4"
                           },
                           "dependencies": {
                             "pinkie": {
@@ -3369,7 +3483,7 @@
                           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                           "dev": true,
                           "requires": {
-                            "is-utf8": "^0.2.0"
+                            "is-utf8": "0.2.1"
                           },
                           "dependencies": {
                             "is-utf8": {
@@ -3388,10 +3502,10 @@
                       "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
                       "dev": true,
                       "requires": {
-                        "hosted-git-info": "^2.1.4",
-                        "is-builtin-module": "^1.0.0",
-                        "semver": "2 || 3 || 4 || 5",
-                        "validate-npm-package-license": "^3.0.1"
+                        "hosted-git-info": "2.1.5",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.1.0",
+                        "validate-npm-package-license": "3.0.1"
                       },
                       "dependencies": {
                         "hosted-git-info": {
@@ -3406,7 +3520,7 @@
                           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                           "dev": true,
                           "requires": {
-                            "builtin-modules": "^1.0.0"
+                            "builtin-modules": "1.1.1"
                           },
                           "dependencies": {
                             "builtin-modules": {
@@ -3429,8 +3543,8 @@
                           "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
                           "dev": true,
                           "requires": {
-                            "spdx-correct": "~1.0.0",
-                            "spdx-expression-parse": "~1.0.0"
+                            "spdx-correct": "1.0.2",
+                            "spdx-expression-parse": "1.0.2"
                           },
                           "dependencies": {
                             "spdx-correct": {
@@ -3439,7 +3553,7 @@
                               "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
                               "dev": true,
                               "requires": {
-                                "spdx-license-ids": "^1.0.2"
+                                "spdx-license-ids": "1.2.1"
                               },
                               "dependencies": {
                                 "spdx-license-ids": {
@@ -3456,8 +3570,8 @@
                               "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
                               "dev": true,
                               "requires": {
-                                "spdx-exceptions": "^1.0.4",
-                                "spdx-license-ids": "^1.0.0"
+                                "spdx-exceptions": "1.0.4",
+                                "spdx-license-ids": "1.2.1"
                               },
                               "dependencies": {
                                 "spdx-exceptions": {
@@ -3484,9 +3598,9 @@
                       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                       "dev": true,
                       "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "graceful-fs": "4.1.4",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
                       },
                       "dependencies": {
                         "graceful-fs": {
@@ -3507,7 +3621,7 @@
                           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
                           "dev": true,
                           "requires": {
-                            "pinkie": "^2.0.0"
+                            "pinkie": "2.0.4"
                           },
                           "dependencies": {
                             "pinkie": {
@@ -3542,9 +3656,9 @@
               "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo=",
               "dev": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.0.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               },
               "dependencies": {
                 "code-point-at": {
@@ -3553,7 +3667,7 @@
                   "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
                   "dev": true,
                   "requires": {
-                    "number-is-nan": "^1.0.0"
+                    "number-is-nan": "1.0.0"
                   },
                   "dependencies": {
                     "number-is-nan": {
@@ -3570,7 +3684,7 @@
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
                   "requires": {
-                    "number-is-nan": "^1.0.0"
+                    "number-is-nan": "1.0.0"
                   },
                   "dependencies": {
                     "number-is-nan": {
@@ -3587,7 +3701,7 @@
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "^2.0.0"
+                    "ansi-regex": "2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -3618,8 +3732,8 @@
               "integrity": "sha1-HzZ9ycbPpWYLaXEjDzsnf8Xjrco=",
               "dev": true,
               "requires": {
-                "camelcase": "^2.1.1",
-                "lodash.assign": "^4.0.6"
+                "camelcase": "2.1.1",
+                "lodash.assign": "4.0.9"
               },
               "dependencies": {
                 "camelcase": {
@@ -3657,13 +3771,14 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
     },
     "opener": {
       "version": "1.4.3",
@@ -3677,12 +3792,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "os-homedir": {
@@ -3690,11 +3805,6 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
-    },
-    "os-shim": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc="
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -3706,7 +3816,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "path-exists": {
@@ -3714,7 +3824,7 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
@@ -3740,9 +3850,9 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "pify": {
@@ -3760,7 +3870,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pluralize": {
@@ -3778,7 +3888,8 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
     },
     "progress": {
       "version": "1.1.8",
@@ -3801,9 +3912,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -3811,22 +3922,23 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       }
     },
     "readable-stream": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
       "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+      "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.0.3",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
       }
     },
     "readline2": {
@@ -3835,8 +3947,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
         "mute-stream": "0.0.5"
       },
       "dependencies": {
@@ -3846,7 +3958,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "mute-stream": {
@@ -3862,8 +3974,8 @@
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "repeating": {
@@ -3871,7 +3983,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "require-uncached": {
@@ -3880,8 +3992,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       }
     },
     "resolve": {
@@ -3890,7 +4002,7 @@
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resolve-from": {
@@ -3903,9 +4015,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
       "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
       }
     },
     "resumer": {
@@ -3914,7 +4027,7 @@
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "dev": true,
       "requires": {
-        "through": "~2.3.4"
+        "through": "2.3.8"
       }
     },
     "rimraf": {
@@ -3923,7 +4036,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "run-async": {
@@ -3931,13 +4044,8 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
-    },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
     },
     "rx-lite": {
       "version": "3.1.2",
@@ -3945,12 +4053,20 @@
       "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
       "dev": true
     },
+    "rxjs": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
+      "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
+      "requires": {
+        "tslib": "1.9.3"
+      }
+    },
     "s3signed": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/s3signed/-/s3signed-0.1.0.tgz",
       "integrity": "sha1-rgO4YllBMhXtQ+mShcjDR1eXNfs=",
       "requires": {
-        "aws-sdk": "^2.0.4"
+        "aws-sdk": "2.197.0"
       }
     },
     "s3urls": {
@@ -3958,14 +4074,20 @@
       "resolved": "https://registry.npmjs.org/s3urls/-/s3urls-1.5.2.tgz",
       "integrity": "sha1-GCqZEgj8GrUhREPrJQ/I9TtLyeo=",
       "requires": {
-        "minimist": "^1.1.0",
-        "s3signed": "^0.1.0"
+        "minimist": "1.2.0",
+        "s3signed": "0.1.0"
       }
     },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "samsam": {
       "version": "1.1.2",
@@ -4003,7 +4125,7 @@
         "formatio": "1.1.1",
         "lolex": "1.3.2",
         "samsam": "1.1.2",
-        "util": ">=0.10.3 <1"
+        "util": "0.10.3"
       }
     },
     "slice-ansi": {
@@ -4012,21 +4134,12 @@
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
-    "spawn-sync": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-      "requires": {
-        "concat-stream": "^1.4.7",
-        "os-shim": "^0.1.2"
-      }
-    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "requires": {
-        "spdx-license-ids": "^1.0.2"
+        "spdx-license-ids": "1.2.2"
       }
     },
     "spdx-expression-parse": {
@@ -4050,8 +4163,8 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "strip-ansi": {
@@ -4059,7 +4172,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -4070,31 +4183,34 @@
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.0",
-        "function-bind": "^1.0.2"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0",
+        "function-bind": "1.1.1"
       }
     },
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         }
       }
     },
@@ -4103,7 +4219,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-indent": {
@@ -4111,7 +4227,7 @@
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "strip-json-comments": {
@@ -4123,7 +4239,8 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
     },
     "table": {
       "version": "3.8.3",
@@ -4131,12 +4248,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "^4.7.0",
-        "ajv-keywords": "^1.0.0",
-        "chalk": "^1.1.1",
-        "lodash": "^4.0.0",
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.5",
         "slice-ansi": "0.0.4",
-        "string-width": "^2.0.0"
+        "string-width": "2.1.1"
       }
     },
     "tape": {
@@ -4145,19 +4262,19 @@
       "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
       "dev": true,
       "requires": {
-        "deep-equal": "~1.0.1",
-        "defined": "~1.0.0",
-        "for-each": "~0.3.2",
-        "function-bind": "~1.1.0",
-        "glob": "~7.1.2",
-        "has": "~1.0.1",
-        "inherits": "~2.0.3",
-        "minimist": "~1.2.0",
-        "object-inspect": "~1.3.0",
-        "resolve": "~1.4.0",
-        "resumer": "~0.0.0",
-        "string.prototype.trim": "~1.1.2",
-        "through": "~2.3.8"
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.2",
+        "function-bind": "1.1.1",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.3.0",
+        "resolve": "1.4.0",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
       }
     },
     "text-table": {
@@ -4171,14 +4288,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
-    "tmp": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-      "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
-      "requires": {
-        "os-tmpdir": "~1.0.1"
-      }
-    },
     "traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
@@ -4190,19 +4299,25 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
     },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "url": {
       "version": "0.10.3",
@@ -4219,7 +4334,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "util": {
@@ -4242,7 +4357,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "uuid": {
       "version": "3.1.0",
@@ -4254,8 +4370,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "requires": {
-        "spdx-correct": "~1.0.0",
-        "spdx-expression-parse": "~1.0.0"
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
       }
     },
     "wcwidth": {
@@ -4264,7 +4380,7 @@
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "optional": true,
       "requires": {
-        "defaults": "^1.0.3"
+        "defaults": "1.0.3"
       }
     },
     "wordwrap": {
@@ -4284,7 +4400,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "xml2js": {
@@ -4292,8 +4408,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
       "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "^4.1.0"
+        "sax": "1.2.1",
+        "xmlbuilder": "4.2.1"
       }
     },
     "xmlbuilder": {
@@ -4301,7 +4417,7 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
       "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
       "requires": {
-        "lodash": "^4.0.0"
+        "lodash": "4.17.5"
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "diff": "^3.2.0",
     "easy-table": "^1.0.0",
     "fasterror": "^1.0.0",
-    "inquirer": "^2.0.0",
+    "inquirer": "^6.1.0",
     "json-diff": "^0.3.1",
     "json-stable-stringify": "1.0.1",
     "meow": "^3.7.0",


### PR DESCRIPTION
This version includes https://github.com/SBoudrias/Inquirer.js/pull/700, which enables a user to enter an empty input value for an input with a default value.

To enter an empty value, a user hits the backspace key when the input is empty. This clears the default value.

Demo (in combination with updating mbxcli):

![2018-08-07-clear-defaults-2](https://user-images.githubusercontent.com/357481/43782607-b9aee1fe-9a2d-11e8-8135-5659263faa35.gif)

@rclark 