### PR TITLE
Create stacks via ChangeSets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
+## 2.20.0 - 2018-09-26
+
+- Create stacks via CloudFormation ChangeSets instead of CreateStack API
+- Remove unused internal functions
+  - `commands.operations.createStack`
+  - `actions.create`
+  - `actions.update`
+
 ## 2.19.0 - 2018-09-19
 
 - Allow template body as parameter to create/update

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -34,58 +34,21 @@ var colors = {
 var actions = module.exports = {};
 
 /**
- * Create a new CloudFormation stack
- *
- * @param {string} name - the name of the new stack
- * @param {string} region - the region to launch the stack into
- * @param {string} templateUrl - the URL for the template on S3
- * @param {object} parameters - name/value pairs defining the desired stack configuration
- * @param {function} callback - a function called when stack creation is complete
- */
-actions.create = function(name, region, templateUrl, parameters, callback) {
-  var cfn = new AWS.CloudFormation({ region: region });
-  var params = stackParameters(name, templateUrl, parameters);
-
-  cfn.createStack(params, function(err) {
-    if (err) return callback(new actions.CloudFormationError('%s: %s', err.code, err.message));
-    callback();
-  });
-};
-
-/**
- * Update an existing CloudFormation stack
- *
- * @param {string} name - the name of the existing stack to update
- * @param {string} region - the region the stack is in
- * @param {string} templateUrl - the URL for the template on S3
- * @param {object} parameters - name/value pairs defining the desired stack configuration
- * @param {function} callback - a function called when the stack update has been invoked
- */
-actions.update = function(name, region, templateUrl, parameters, callback) {
-  var cfn = new AWS.CloudFormation({ region: region });
-  var params = stackParameters(name, templateUrl, parameters);
-
-  cfn.updateStack(params, function(err) {
-    if (err) return callback(new actions.CloudFormationError('%s: %s', err.code, err.message));
-    callback();
-  });
-};
-
-/**
  * Determine what will change about an existing CloudFormation stack by
  * performing a specific update
  *
  * @param {string} name - the name of the existing stack to update
  * @param {string} region - the region the stack is in
+ * @param {string} changeSetType - the type of changeset, either UPDATE or CREATE
  * @param {string} templateUrl - the URL for the template on S3
  * @param {object} parameters - name/value pairs defining the desired stack configuration
  * @param {function} callback - a function provided with a summary of the changes that
  * this change will perform to stack resources
  */
-actions.diff = function(name, region, templateUrl, parameters, callback) {
+actions.diff = function(name, region, changeSetType, templateUrl, parameters, callback) {
   var cfn = new AWS.CloudFormation({ region: region });
   var changesetId = 'a' + crypto.randomBytes(16).toString('hex');
-  var params = stackParameters(name, templateUrl, parameters);
+  var params = stackParameters(name, changeSetType, templateUrl, parameters);
   params.ChangeSetName = changesetId;
 
   cfn.createChangeSet(params, function(err) {
@@ -363,17 +326,19 @@ function describeChangeset(cfn, name, changesetId, callback) {
  *
  * @private
  * @param {string} name - the name of the stack
+ * @param {string} changeSetType - the type of changeset, either UPDATE or CREATE
  * @param {string} templateUrl - the URL for the template on S3
  * @param {object} parameters - name/value pairs defining the desired stack configuration
  * @returns {object} params - an object for use in create/update/delete stack requests
  */
-function stackParameters(name, templateUrl, parameters) {
+function stackParameters(name, changeSetType, templateUrl, parameters) {
   return {
     StackName: name,
     Capabilities: [
       'CAPABILITY_IAM',
       'CAPABILITY_NAMED_IAM'
     ],
+    ChangeSetType: changeSetType,
     TemplateURL: templateUrl,
     Parameters: Object.keys(parameters).map(function(key) {
       return { ParameterKey: key, ParameterValue: parameters[key] };

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -90,7 +90,8 @@ module.exports = function(config) {
       operations.mergeMetadata,
       operations.saveTemplate,
       operations.validateTemplate,
-      operations.createStack,
+      operations.getChangesetCreate,
+      operations.executeChangeSet,
       operations.monitorStack,
       operations.saveConfig
     ], callback);
@@ -131,7 +132,7 @@ module.exports = function(config) {
       operations.saveTemplate,
       operations.validateTemplate,
       operations.beforeUpdateHook,
-      operations.getChangeset,
+      operations.getChangesetUpdate,
       operations.confirmChangeset,
       operations.executeChangeSet,
       operations.monitorStack,
@@ -480,7 +481,15 @@ var operations = module.exports.operations = {
     });
   },
 
-  getChangeset: function(context) {
+  getChangesetCreate: function(context) {
+    operations.getChangeset(context, 'CREATE');
+  },
+
+  getChangesetUpdate: function(context) {
+    operations.getChangeset(context, 'UPDATE');
+  },
+
+  getChangeset: function(context, changeSetType) {
     function finished(err, details) {
       if (err) {
         var msg = 'Failed to generate changeset: '; // err instanceof actions.CloudFormationError
@@ -496,6 +505,7 @@ var operations = module.exports.operations = {
     actions.diff(
       context.stackName,
       context.stackRegion,
+      changeSetType,
       context.templateUrl,
       context.newParameters,
       finished
@@ -611,27 +621,6 @@ var operations = module.exports.operations = {
       if (!ready) return context.abort();
       context.next();
     });
-  },
-
-  createStack: function(context) {
-    function finished(err) {
-      if (err) {
-        var msg = 'Failed to create stack: '; // err instanceof actions.CloudFormationError
-        msg += err.message;
-        err.message = msg;
-        return context.abort(err);
-      }
-
-      context.next();
-    }
-
-    actions.create(
-      context.stackName,
-      context.stackRegion,
-      context.templateUrl,
-      context.newParameters,
-      finished
-    );
   },
 
   confirmDelete: function(context) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/cfn-config",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git"
   },
   "author": "Mapbox",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "dependencies": {
     "aws-sdk": "^2.288.0",
     "cfn-stack-event-stream": "0.0.7",


### PR DESCRIPTION
Fixes https://github.com/mapbox/cfn-config/issues/138

The main change happens in `lib/command` where we use changesets instead of createStack. I decided that `confirmChangeset` is not necessary during a create, since it only shows newly created resources anyways. Users should see no impact of this change (except maybe that a create takes a couple of seconds longer due to changeset creation).

The `cfn.createChangeSet` API needs `ChangeSetType` set depending if this is a create or update. Therefore the changes in `lib/actions` that tunnel this new parameter through.

While working on the tests I realized that there are three unused functions, which I removed together with their tests:

- `commands.operations.createStack`
- `actions.create`
- `actions.update`

Next:

- [x] Manually verify `create` works
- [x] Manually verify  `update` works
- [x] 👀@rclark 
- [ ] Merge and release