### PR TITLE
Fix cli printing "true" after certain stack commands

### DIFF
--- a/bin/cfn-config.js
+++ b/bin/cfn-config.js
@@ -10,6 +10,6 @@ cli.main(parsed, finished);
 
 function finished(err, data) {
   if (err) process.stderr.write(err.message + '\n');
-  if (data) process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+  if (data && data !== true) process.stdout.write(JSON.stringify(data, null, 2) + '\n');
   process.exit(err ? 1 : 0);
 }


### PR DESCRIPTION
Fixes #119 

When stack commands that use a `context` successfully complete, the `context` created by `commandContext` will [invoke the final callback with `true` as the second parameter](https://github.com/mapbox/cfn-config/blob/94d5510610645ac94ee15f84bb54545099591b64/lib/commands.js#L257). This ends up getting passed to this `finished` function and interpreted as `data` that is supposed to be printed to the terminal. But the only data we _want_ to print here is the output of the `info` command.

Here's a screen-cap of my terminal executing a stack update command with this fix applied:

![image](https://user-images.githubusercontent.com/357481/87495747-25950e00-c620-11ea-9499-3df103ebd6cd.png)

cc @rclark 