### PR TITLE
If a parameter is overridden, do not UsePreviousValue

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -360,7 +360,11 @@ var operations = module.exports.operations = {
           context.newParameters[key] = value;
         }
       });
-      context.changesetParameters = changesetParameters(context.oldParameters, context.newParameters);
+      context.changesetParameters = changesetParameters(
+        context.oldParameters,
+        context.newParameters,
+        overrideParameters
+      );
       return context.next();
     }
     else {
@@ -375,7 +379,11 @@ var operations = module.exports.operations = {
 
     prompt.parameters(questions, function(err, answers) {
       context.newParameters = answers;
-      context.changesetParameters = changesetParameters(context.oldParameters, context.newParameters);
+      context.changesetParameters = changesetParameters(
+        context.oldParameters,
+        context.newParameters,
+        overrideParameters
+      );
       context.next();
     });
   },
@@ -837,14 +845,17 @@ function stackName(name, suffix) {
  * @private
  * @param {object} oldParameters - name/value pairs defining old or default parameters
  * @param {object} newParameters - name/value pairs defining the new, unchanged old, or accepted default parameters
+ * @param {object} [overrideParameters={}] - name/value pairs for any parameter values passed as overrides
  * @returns {array} params - parameters objects for use in ChangeSet requests that create/update a stack
  */
-function changesetParameters(oldParameters, newParameters) {
+function changesetParameters(oldParameters, newParameters, overrideParameters) {
+  overrideParameters = overrideParameters || {};
+
   return Object.entries(newParameters).map(([key, value]) => {
     const parameter = {
       ParameterKey: key
     };
-    if (oldParameters[key] === newParameters[key]) {
+    if (!overrideParameters[key] && oldParameters[key] === newParameters[key]) {
       Object.assign(parameter, { UsePreviousValue: true });
     }
     else {

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -363,7 +363,8 @@ var operations = module.exports.operations = {
       context.changesetParameters = changesetParameters(
         context.oldParameters,
         context.newParameters,
-        overrideParameters
+        overrideParameters,
+        context.create
       );
       return context.next();
     }
@@ -382,7 +383,8 @@ var operations = module.exports.operations = {
       context.changesetParameters = changesetParameters(
         context.oldParameters,
         context.newParameters,
-        overrideParameters
+        overrideParameters,
+        context.create
       );
       context.next();
     });
@@ -561,6 +563,7 @@ var operations = module.exports.operations = {
 
   createPreamble: function(context) {
     var preamble = d3.queue();
+    context.create = true;
 
     if (!context.template) {
       preamble.defer((next) => next(new template.NotFoundError('No template passed')));
@@ -846,21 +849,24 @@ function stackName(name, suffix) {
  * @param {object} oldParameters - name/value pairs defining old or default parameters
  * @param {object} newParameters - name/value pairs defining the new, unchanged old, or accepted default parameters
  * @param {object} [overrideParameters={}] - name/value pairs for any parameter values passed as overrides
+ * @param {boolean} isCreate - indicates that UsePreviousValue shoudld not be used on stack create. set in createPreable().
  * @returns {array} params - parameters objects for use in ChangeSet requests that create/update a stack
  */
-function changesetParameters(oldParameters, newParameters, overrideParameters) {
+function changesetParameters(oldParameters, newParameters, overrideParameters, isCreate) {
   overrideParameters = overrideParameters || {};
 
   return Object.entries(newParameters).map(([key, value]) => {
     const parameter = {
       ParameterKey: key
     };
-    if (!overrideParameters[key] && oldParameters[key] === newParameters[key]) {
-      Object.assign(parameter, { UsePreviousValue: true });
-    }
-    else {
-      Object.assign(parameter, { ParameterValue: value });
-    }
+
+    const unchanged = oldParameters[key] === newParameters[key];
+    const isOverriden = overrideParameters[key] && unchanged;
+    
+    if (isCreate || isOverriden) parameter.ParameterValue = value;
+    else if (unchanged) parameter.UsePreviousValue = true;
+    else parameter.ParameterValue = value;
+
     return parameter;
   });
 }


### PR DESCRIPTION
This fixes #180, a regression in handling parameter overrides introduced in v3.0.0.

cc @ingalls -- also just an fyi we have not yet integrated with cfn-config v3 over here with `mbx`.