### PR TITLE
Test override

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -363,7 +363,8 @@ var operations = module.exports.operations = {
       context.changesetParameters = changesetParameters(
         context.oldParameters,
         context.newParameters,
-        overrideParameters
+        overrideParameters,
+        context.create
       );
       return context.next();
     }
@@ -382,7 +383,8 @@ var operations = module.exports.operations = {
       context.changesetParameters = changesetParameters(
         context.oldParameters,
         context.newParameters,
-        overrideParameters
+        overrideParameters,
+        context.create
       );
       context.next();
     });
@@ -561,6 +563,7 @@ var operations = module.exports.operations = {
 
   createPreamble: function(context) {
     var preamble = d3.queue();
+    context.create = true;
 
     if (!context.template) {
       preamble.defer((next) => next(new template.NotFoundError('No template passed')));
@@ -846,16 +849,18 @@ function stackName(name, suffix) {
  * @param {object} oldParameters - name/value pairs defining old or default parameters
  * @param {object} newParameters - name/value pairs defining the new, unchanged old, or accepted default parameters
  * @param {object} [overrideParameters={}] - name/value pairs for any parameter values passed as overrides
+ * @param {boolean} isCreate - indicates that UsePreviousValue shoudld not be used on stack create. set in createPreable().
  * @returns {array} params - parameters objects for use in ChangeSet requests that create/update a stack
  */
-function changesetParameters(oldParameters, newParameters, overrideParameters) {
+function changesetParameters(oldParameters, newParameters, overrideParameters, isCreate) {
   overrideParameters = overrideParameters || {};
 
   return Object.entries(newParameters).map(([key, value]) => {
     const parameter = {
       ParameterKey: key
     };
-    if (!overrideParameters[key] && oldParameters[key] === newParameters[key]) {
+
+    if (!isCreate && !overrideParameters[key] && oldParameters[key] === newParameters[key]) {
       Object.assign(parameter, { UsePreviousValue: true });
     }
     else {

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -866,11 +866,7 @@ function changesetParameters(oldParameters, newParameters, overrideParameters, i
     if (isCreate || isOverriden) parameter.ParameterValue = value;
     else if (unchanged) parameter.UsePreviousValue = true;
     else parameter.ParameterValue = value;
-      Object.assign(parameter, { UsePreviousValue: true });
-    }
-    else {
-      Object.assign(parameter, { ParameterValue: value });
-    }
+
     return parameter;
   });
 }

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -860,7 +860,12 @@ function changesetParameters(oldParameters, newParameters, overrideParameters, i
       ParameterKey: key
     };
 
-    if (!isCreate && !overrideParameters[key] && oldParameters[key] === newParameters[key]) {
+    const unchanged = oldParameters[key] === newParameters[key];
+    const isOverriden = overrideParameters[key] && unchanged;
+    
+    if (isCreate || isOverriden) parameter.ParameterValue = value;
+    else if (unchanged) parameter.UsePreviousValue = true;
+    else parameter.ParameterValue = value;
       Object.assign(parameter, { UsePreviousValue: true });
     }
     else {

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1064,6 +1064,54 @@ test('[commands.operations.promptParameters] changesetParameters use previous va
   commands.operations.promptParameters(context);
 });
 
+test('[commands.operations.promptParameters] changesetParameters does not set UsePreviousValue when overrides set the value', function(assert) {
+  var oldParameters = { beep: 'bop' };
+  var newParameters = { beep: 'boop' };
+
+  sinon.stub(prompt, 'parameters').callsFake(function(questions, callback) {
+    callback(null, newParameters);
+  });
+
+  var context = Object.assign({}, basicContext, {
+    stackRegion: 'us-west-2',
+    newTemplate: { new: 'template' },
+    oldParameters: oldParameters,
+    overrides: { parameters: { beep: 'boop' } },
+    next: function(err) {
+      assert.ifError(err, 'success');
+      assert.deepEqual(context.changesetParameters, [{ ParameterKey: 'beep', ParameterValue: 'boop' }]);
+      prompt.parameters.restore();
+      assert.end();
+    }
+  });
+
+  commands.operations.promptParameters(context);
+});
+
+test('[commands.operations.promptParameters] changesetParameters sets UsePreviousValue to true in the absence of overrides', function(assert) {
+  var oldParameters = { beep: 'bop' };
+  var newParameters = { beep: 'bop' };
+
+  sinon.stub(prompt, 'parameters').callsFake(function(questions, callback) {
+    callback(null, newParameters);
+  });
+
+  var context = Object.assign({}, basicContext, {
+    stackRegion: 'us-west-2',
+    newTemplate: { new: 'template' },
+    oldParameters: oldParameters,
+    overrides: {},
+    next: function(err) {
+      assert.ifError(err, 'success');
+      assert.deepEqual(context.changesetParameters, [{ ParameterKey: 'beep', UsePreviousValue: true }]);
+      prompt.parameters.restore();
+      assert.end();
+    }
+  });
+
+  commands.operations.promptParameters(context);
+});
+
 test('[commands.operations.confirmParameters] force-mode', function(assert) {
   var context = Object.assign({}, basicContext, {
     overrides: { force: true },

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1065,7 +1065,7 @@ test('[commands.operations.promptParameters] changesetParameters use previous va
 });
 
 test('[commands.operations.promptParameters] changesetParameters does not set UsePreviousValue when overrides set the value', function(assert) {
-  var oldParameters = { beep: 'bop' };
+  var oldParameters = { beep: 'boop' };
   var newParameters = { beep: 'boop' };
 
   sinon.stub(prompt, 'parameters').callsFake(function(questions, callback) {
@@ -1113,7 +1113,7 @@ test('[commands.operations.promptParameters] changesetParameters sets UsePreviou
 });
 
 test('[commands.operations.promptParameters] do not set UsePreviousValue when creating a new stack', function(assert) {
-  var oldParameters = { beep: 'bop' };
+  var oldParameters = { beep: 'boop' };
   var newParameters = { beep: 'boop' };
 
   sinon.stub(prompt, 'parameters').callsFake(function(questions, callback) {

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1112,6 +1112,32 @@ test('[commands.operations.promptParameters] changesetParameters sets UsePreviou
   commands.operations.promptParameters(context);
 });
 
+test('[commands.operations.promptParameters] do not set UsePreviousValue when creating a new stack', function(assert) {
+  var oldParameters = { beep: 'bop' };
+  var newParameters = { beep: 'boop' };
+
+  sinon.stub(prompt, 'parameters').callsFake(function(questions, callback) {
+    callback(null, newParameters);
+  });
+
+  var context = Object.assign({}, basicContext, {
+    stackRegion: 'us-west-2',
+    newTemplate: { new: 'template' },
+    create: true,
+    oldParameters: oldParameters,
+    overrides: { parameters: { beep: 'boop' } },
+    next: function(err) {
+      assert.ifError(err, 'success');
+      assert.ok(context.create, 'context.create is set to true');
+      assert.deepEqual(context.changesetParameters, [{ ParameterKey: 'beep', ParameterValue: 'boop' }]);
+      prompt.parameters.restore();
+      assert.end();
+    }
+  });
+
+  commands.operations.promptParameters(context);
+});
+
 test('[commands.operations.confirmParameters] force-mode', function(assert) {
   var context = Object.assign({}, basicContext, {
     overrides: { force: true },
@@ -2026,6 +2052,7 @@ test('[commands.operations.createPreamble] success', function(assert) {
       assert.ifError(err, 'success');
       assert.deepEqual(context.newTemplate, { new: 'template' }, 'set context.newTemplate');
       assert.deepEqual(context.configNames, ['config'], 'set context.configNames');
+      assert.ok(context.create, 'context.create is set to true');
       template.read.restore();
       lookup.configurations.restore();
       assert.end();
@@ -2055,6 +2082,7 @@ test('[commands.operations.createPreamble] success with template object', functi
       assert.ifError(err, 'success');
       assert.deepEqual(context.newTemplate, context.template, 'set context.newTemplate');
       assert.deepEqual(context.configNames, ['config'], 'set context.configNames');
+      assert.ok(context.create, 'context.create is set to true');
       template.read.restore();
       lookup.configurations.restore();
       assert.end();


### PR DESCRIPTION
this PR: 

1. adds a missing test from #181 to assert that if a parameter is overriden, cfn-config does not set UsePreviousValue in the changeset Parameters
2. avoids setting UsePreviousValue on stack create fixing #182 

test that stack create succeeds locally, but would love a review @rclark 