### PR TITLE
Yaml can read

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -3,6 +3,7 @@ var path = require('path');
 var error = require('fasterror');
 var AWS = require('aws-sdk');
 var s3urls = require('s3urls');
+var yaml = require('js-yaml');
 
 var template = module.exports = {};
 
@@ -27,7 +28,13 @@ template.read = function(templatePath, options, callback) {
 
       var templateBody;
 
-      if (!/\.js$/.test(templatePath)) {
+      if (/\.ya?ml$/i.test(templatePath)) {
+        templateBody = fs.readFileSync(templatePath, 'utf8');
+        try { templateBody = yaml.safeLoad(templateBody); }
+        catch (err) { return callback(new template.InvalidTemplateError('Failed to parse %s: %s', templatePath, err.message)); }
+        return callback(null, templateBody);
+      }
+      else if (!/\.js$/.test(templatePath)) {
         templateBody = fs.readFileSync(templatePath);
         try { templateBody = JSON.parse(templateBody); }
         catch (err) { return callback(new template.InvalidTemplateError('Failed to parse %s: %s', templatePath, err.message)); }

--- a/lib/template.js
+++ b/lib/template.js
@@ -3,6 +3,7 @@ var path = require('path');
 var error = require('fasterror');
 var AWS = require('aws-sdk');
 var s3urls = require('s3urls');
+var { CLOUDFORMATION_SCHEMA } = require('js-yaml-cloudformation-schema');
 var yaml = require('js-yaml');
 
 var template = module.exports = {};
@@ -30,7 +31,7 @@ template.read = function(templatePath, options, callback) {
 
       if (/\.ya?ml$/i.test(templatePath)) {
         templateBody = fs.readFileSync(templatePath, 'utf8');
-        try { templateBody = yaml.safeLoad(templateBody); }
+        try { templateBody = yaml.safeLoad(templateBody, { schema: CLOUDFORMATION_SCHEMA }); }
         catch (err) { return callback(new template.InvalidTemplateError('Failed to parse %s: %s', templatePath, err.message)); }
         return callback(null, templateBody);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1818,6 +1818,14 @@
         "esprima": "^4.0.0"
       }
     },
+    "js-yaml-cloudformation-schema": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml-cloudformation-schema/-/js-yaml-cloudformation-schema-1.0.0.tgz",
+      "integrity": "sha512-eokVVPLsjLFuuCRQWIIaE5fX7qPUNRAAmJFXSvtzUnJcdNS0ZtAPdaFcwCrTHM+owGcBR82rlpd0b6bu8pFwQA==",
+      "requires": {
+        "js-yaml": "^3.7.0"
+      }
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -393,7 +393,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -1099,8 +1098,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.0.1",
@@ -1812,10 +1810,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2841,8 +2838,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "string-width": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "easy-table": "^1.0.0",
     "fasterror": "^1.0.0",
     "inquirer": "^6.1.0",
+    "js-yaml": "^3.14.0",
     "json-diff": "^0.5.2",
     "json-stable-stringify": "1.0.1",
     "meow": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "fasterror": "^1.0.0",
     "inquirer": "^6.1.0",
     "js-yaml": "^3.14.0",
+    "js-yaml-cloudformation-schema": "^1.0.0",
     "json-diff": "^0.5.2",
     "json-stable-stringify": "1.0.1",
     "meow": "^5.0.0",

--- a/test/fixtures/malformed-template.yaml
+++ b/test/fixtures/malformed-template.yaml
@@ -1,0 +1,2 @@
+Parameters:
+--

--- a/test/fixtures/template-sync.js
+++ b/test/fixtures/template-sync.js
@@ -35,7 +35,15 @@ module.exports = {
   },
   Resources: {
     Topic: {
-      Type: 'AWS::SNS::Topic'
+      Type: 'AWS::SNS::Topic',
+      Properties: {
+        Tags: [
+          {
+            Key: 'Handedness',
+            Value: { 'Fn::Join': ['/', [{ Ref: 'Name' }, { Ref: 'Handedness' }]] }
+          }
+        ]
+      }
     }
   },
   Outputs: {

--- a/test/fixtures/template.json
+++ b/test/fixtures/template.json
@@ -38,7 +38,15 @@
   },
   "Resources": {
     "Topic": {
-      "Type": "AWS::SNS::Topic"
+      "Type": "AWS::SNS::Topic",
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Handedness",
+            "Value": { "Fn::Join": ["/", [ { "Ref": "Name" }, { "Ref": "Handedness" } ] ] }
+          }
+        ]
+      }
     }
   },
   "Outputs": {

--- a/test/fixtures/template.yaml
+++ b/test/fixtures/template.yaml
@@ -30,6 +30,14 @@ Parameters:
 Resources:
   Topic:
     Type: AWS::SNS::Topic
+    Properties:
+      Tags:
+        - Key: Handedness
+          Value: !Join
+            - /
+            - - !Ref Name
+              - Ref:
+                  Handedness
 Outputs:
   Blah:
     Value: blah

--- a/test/fixtures/template.yaml
+++ b/test/fixtures/template.yaml
@@ -1,0 +1,36 @@
+Parameters:
+  Name:
+    Type: String
+    Description: Someone's first name
+    AllowedPattern: '[A-Z][a-z]+'
+    ConstraintDescription: must be capitalized and only contain letters
+  Age:
+    Type: Number
+    MinValue: 0
+    MaxValue: 150
+  Handedness:
+    Type: String
+    Description: Their dominant hand
+    Default: right
+    AllowedValues:
+      - left
+      - right
+  Pets:
+    Type: CommaDelimitedList
+    Description: The names of their pets
+  LuckyNumbers:
+    Type: List<Number>
+    Description: Their lucky numbers
+  SecretPassword:
+    Type: String
+    Description: '[secure] Their secret password'
+    MinLength: 8
+    MaxLength: 24
+    NoEcho: true
+Resources:
+  Topic:
+    Type: AWS::SNS::Topic
+Outputs:
+  Blah:
+    Value: blah
+    Description: nothing

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -33,6 +33,14 @@ test('[template.read] local js file cannot be parsed', function(assert) {
   });
 });
 
+test('[template.read] local yaml file cannot be parsed', function(assert) {
+  template.read(path.resolve(__dirname, 'fixtures', 'malformed-template.yaml'), function(err) {
+    assert.ok(err instanceof template.InvalidTemplateError, 'returned expected error');
+    assert.ok(/Failed to parse .*/.test(err.message), 'passthrough parse error');
+    assert.end();
+  });
+});
+
 test('[template.read] S3 no access', function(assert) {
   template.read('s3://mapbox/fake', function(err) {
     assert.ok(err instanceof template.NotFoundError, 'returned expected error');
@@ -94,6 +102,14 @@ test('[template.read] S3 file cannot be parsed', function(assert) {
   template.read('s3://my/template', function(err) {
     assert.ok(err instanceof template.InvalidTemplateError, 'returned expected error');
     AWS.S3.restore();
+  });
+});
+
+test('[template.read] local YAML', function(assert) {
+  template.read(path.resolve(__dirname, 'fixtures', 'template.yaml'), function(err, found) {
+    assert.ifError(err, 'success');
+    assert.deepEqual(found, expected, 'got template JSON');
+    assert.end();
   });
 });
 


### PR DESCRIPTION
Adds the ability to use YAML formatted Cloudformation templates, even if they use short form syntax for (intrinsic functions)[https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html].

Parsing plain old YAML is fairly straightforward, but out of the box, usage of short form syntax for things like `!Ref` and `!Sub` breaks the YAML parser. Luckily, `js-yaml` has a facility for providing a custom schema for handling custom YAML tags (which is what that short form syntax is). That schema is provided by [`js-yaml-cloudformation-schema`](https://github.com/danmactough/js-yaml-cloudformation-schema).

Note that this doesn't change the _output_ of templates (such as when they are saved to S3), which keeps things simple -- the diffing and whatnot _should not_ be affected by this at all. (In other words, we basically perform an inline [`cfn-flip`](https://github.com/awslabs/aws-cfn-template-flip) and from that point forward, the data is the data, and it doesn't matter if it was ingested from YAML or JSON or JS.)

That being said, I'm not sure if there's anything else that would require testing, so please let me know if there is.

cc @rclark 