### PR TITLE
Get original template stage for diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
+## HEAD
+- Template lookups always get the `Original` template stage. This means that the template diff will compare your new template with the existing template before CloudFormation transforms and macros were applied to it.
+
 ## 3.0.0 - 2020-07-31
 - When a stack parameter value is not changed, then `UsePreviousValue` is set to `true` in CloudFormation UpdateStack API calls.
 - This solves a bug where template parameters defined with `NoEcho: true` would see their values replaced by `****` during an update.

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -118,7 +118,7 @@ lookup.info = function(name, region, resources, decrypt, callback) {
  */
 lookup.template = function(name, region, callback) {
   var cfn = new AWS.CloudFormation({ region: region });
-  cfn.getTemplate({ StackName: name }, function(err, data) {
+  cfn.getTemplate({ StackName: name, TemplateStage: 'Original' }, function(err, data) {
     if (err && err.code === 'ValidationError' && /Stack with id/.test(err.message))
       return callback(new lookup.StackNotFoundError('Stack %s not found in %s', name, region));
     if (err) return callback(new lookup.CloudFormationError('%s: %s', err.code, err.message));

--- a/test/lookups.test.js
+++ b/test/lookups.test.js
@@ -351,6 +351,11 @@ test('[lookup.template] stack does not exist', function(assert) {
 
 test('[lookup.template] success', function(assert) {
   AWS.stub('CloudFormation', 'getTemplate', function(params, callback) {
+    assert.deepEqual(params, {
+      StackName: 'my-stack',
+      TemplateStage: 'Original'
+    }, 'getTemplate call sets the TemplateStage');
+
     callback(null, {
       RequestMetadata: { RequestId: 'db317457-46f2-11e6-8ee0-fbc06d2d1322' },
       TemplateBody: JSON.stringify(template)


### PR DESCRIPTION
This PR improves cfn-config's compatibility with [CloudFormation macros](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-macros.html) by specifying the `TemplateStage` when we get the live template for diffing. The diff should compare the new user-defined template with the live user-defined template, not the live template after processing.

I need to try this out on a real template, then I will ask for a review.