### PR TITLE
CAPABILITY_AUTO_EXPAND

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Quickly configure and start AWS CloudFormation stacks
     -f, --force             perform a create/update/delete command without any
                             prompting, accepting all defaults
     -e, --extended          display resource details with the info command
+    -x, --expand            Add CAPABILITY_AUTO_EXPAND to the changeset capabilities.
+                            This allows transformation macros to be expanded on stack
+                            creation or update.
 ```
 
 ## JavaScript Installation

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -45,10 +45,10 @@ var actions = module.exports = {};
  * @param {function} callback - a function provided with a summary of the changes that
  * this change will perform to stack resources
  */
-actions.diff = function(name, region, changeSetType, templateUrl, parameters, callback) {
+actions.diff = function(name, region, changeSetType, templateUrl, parameters, expand, callback) {
   var cfn = new AWS.CloudFormation({ region: region });
   var changesetId = 'a' + crypto.randomBytes(16).toString('hex');
-  var changeSetParameters = changeSet(name, changeSetType, templateUrl, parameters);
+  var changeSetParameters = changeSet(name, changeSetType, templateUrl, parameters, expand);
   changeSetParameters.ChangeSetName = changesetId;
 
   cfn.createChangeSet(changeSetParameters, function(err) {
@@ -327,18 +327,21 @@ function describeChangeset(cfn, name, changesetId, callback) {
  * @param {object} parameters - parameters for the ChangeSet
  * @returns {object} changeset - an object for use in ChangeSet requests that create/update a stack
  */
-function changeSet(name, changeSetType, templateUrl, parameters) {
-  return {
+function changeSet(name, changeSetType, templateUrl, parameters, expand) {
+  const base = {
     StackName: name,
     Capabilities: [
       'CAPABILITY_IAM',
-      'CAPABILITY_NAMED_IAM',
-      'CAPABILITY_AUTO_EXPAND'
+      'CAPABILITY_NAMED_IAM'
     ],
     ChangeSetType: changeSetType,
     TemplateURL: templateUrl,
     Parameters: parameters
   };
+
+  if (expand) base.Capabilities.push('CAPABILITY_AUTO_EXPAND');
+
+  return base;
 }
 
 function currentTime() {

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -332,7 +332,8 @@ function changeSet(name, changeSetType, templateUrl, parameters) {
     StackName: name,
     Capabilities: [
       'CAPABILITY_IAM',
-      'CAPABILITY_NAMED_IAM'
+      'CAPABILITY_NAMED_IAM',
+      'CAPABILITY_AUTO_EXPAND'
     ],
     ChangeSetType: changeSetType,
     TemplateURL: templateUrl,

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -42,6 +42,9 @@ function parse(args, env) {
         -e, --extended          display resource details with the info command
         -d, --decrypt           decrypt secure parameters with the info command
         -p, --parameters        JSON string of parameters to override on create/update
+        -x, --expand            Add CAPABILITY_AUTO_EXPAND to the changeset capabilities.
+                                This allows transformation macros to be expanded on stack
+                                creation or update.
     `,
     flags: {
       'config-bucket': {
@@ -85,6 +88,11 @@ function parse(args, env) {
         alias: 'p',
         type: 'string',
         default: undefined
+      },
+      expand: {
+        alias: 'x',
+        type: 'boolean',
+        defaults: false
       }
     }
   });
@@ -110,7 +118,7 @@ function parse(args, env) {
     command: cli.input[0],
     environment: cli.input[1],
     templatePath: cli.input[2] ? path.resolve(cli.input[2]) : undefined,
-    overrides: { force: cli.flags.force, kms: cli.flags.kms, parameters: cli.flags.parameters },
+    overrides: { force: cli.flags.force, kms: cli.flags.kms, parameters: cli.flags.parameters, expand: cli.flags.expand },
     options: cli.flags,
     help: cli.help
   };

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -526,6 +526,7 @@ var operations = module.exports.operations = {
       changeSetType,
       context.templateUrl,
       context.changesetParameters,
+      context.overrides.expand,
       finished
     );
   },
@@ -862,7 +863,7 @@ function changesetParameters(oldParameters, newParameters, overrideParameters, i
 
     const unchanged = oldParameters[key] === newParameters[key];
     const isOverriden = overrideParameters[key] && unchanged;
-    
+
     if (isCreate || isOverriden) parameter.ParameterValue = value;
     else if (unchanged) parameter.UsePreviousValue = true;
     else parameter.ParameterValue = value;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/cfn-config",
-  "version": "3.1.0",
+  "version": "3.2.0-dev1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git"
   },
   "author": "Mapbox",
-  "version": "3.1.0",
+  "version": "3.2.0-dev1",
   "dependencies": {
     "aws-sdk": "^2.720.0",
     "cfn-stack-event-stream": "^1.0.1",

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -166,7 +166,7 @@ test('[actions.diff] success', function(assert) {
       ChangeSetName: params.ChangeSetName,
       ChangeSetType: 'UPDATE',
       StackName: 'my-stack',
-      Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+      Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
       Parameters: [
         { ParameterKey: 'Name', ParameterValue: 'Chuck' },
         { ParameterKey: 'Age', ParameterValue: 18 },
@@ -268,7 +268,7 @@ test('[actions.diff] success', function(assert) {
     { ParameterKey: 'SecretPassword', ParameterValue: 'secret' }
   ];
 
-  actions.diff('my-stack', 'us-east-1', 'UPDATE', url, parameters, false, function(err, data) {
+  actions.diff('my-stack', 'us-east-1', 'UPDATE', url, parameters, true, function(err, data) {
     assert.ifError(err, 'success');
     assert.deepEqual(data, {
       id: 'aa507e2bdfc55947035a07271e75384efe',

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -12,7 +12,7 @@ test('[actions.diff] stack does not exist', function(assert) {
     callback(err);
   });
 
-  actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, function(err) {
+  actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, false, function(err) {
     assert.ok(err instanceof actions.CloudFormationError, 'expected error returned');
     AWS.CloudFormation.restore();
     assert.end();
@@ -26,7 +26,7 @@ test('[actions.diff] invalid parameters', function(assert) {
     callback(err);
   });
 
-  actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, function(err) {
+  actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, false, function(err) {
     assert.ok(err instanceof actions.CloudFormationError, 'expected error returned');
     AWS.CloudFormation.restore();
     assert.end();
@@ -40,7 +40,7 @@ test('[actions.diff] template url does not exist', function(assert) {
     callback(err);
   });
 
-  actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, function(err) {
+  actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, false, function(err) {
     assert.ok(err instanceof actions.CloudFormationError, 'expected error returned');
     AWS.CloudFormation.restore();
     assert.end();
@@ -54,7 +54,7 @@ test('[actions.diff] template url is invalid', function(assert) {
     callback(err);
   });
 
-  actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, function(err) {
+  actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, false, function(err) {
     assert.ok(err instanceof actions.CloudFormationError, 'expected error returned');
     AWS.CloudFormation.restore();
     assert.end();
@@ -68,7 +68,7 @@ test('[actions.diff] template is invalid', function(assert) {
     callback(err);
   });
 
-  actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, function(err) {
+  actions.diff('my-stack', 'us-east-1', 'UPDATE', 'https://my-bucket.s3.amazonaws.com/my-template.json', {}, false, function(err) {
     assert.ok(err instanceof actions.CloudFormationError, 'expected error returned');
     AWS.CloudFormation.restore();
     assert.end();
@@ -84,7 +84,7 @@ test('[actions.diff] createChangeSet error on wrong changeSetType', function(ass
     callback(err);
   });
 
-  actions.diff('my-stack', 'us-east-1', 'INVALID', url, {}, function(err) {
+  actions.diff('my-stack', 'us-east-1', 'INVALID', url, {}, false, function(err) {
     assert.ok(err instanceof actions.CloudFormationError, 'expected error returned');
     AWS.CloudFormation.restore();
     assert.end();
@@ -98,7 +98,7 @@ test('[actions.diff] unexpected createChangeSet error', function(assert) {
     callback(new Error('unexpected'));
   });
 
-  actions.diff('my-stack', 'us-east-1', 'UPDATE', url, {}, function(err) {
+  actions.diff('my-stack', 'us-east-1', 'UPDATE', url, {}, false, function(err) {
     assert.ok(err instanceof actions.CloudFormationError, 'expected error returned');
     AWS.CloudFormation.restore();
     assert.end();
@@ -116,7 +116,7 @@ test('[actions.diff] unexpected describeChangeSet error', function(assert) {
     callback(new Error('unexpected'));
   });
 
-  actions.diff('my-stack', 'us-east-1', 'UPDATE', url, {}, function(err) {
+  actions.diff('my-stack', 'us-east-1', 'UPDATE', url, {}, false, function(err) {
     assert.ok(err instanceof actions.CloudFormationError, 'expected error returned');
     AWS.CloudFormation.restore();
     assert.end();
@@ -143,7 +143,7 @@ test('[actions.diff] changeset failed to create', function(assert) {
     });
   });
 
-  actions.diff('my-stack', 'us-east-1', 'UPDATE', url, {}, function(err, data) {
+  actions.diff('my-stack', 'us-east-1', 'UPDATE', url, {}, false, function(err, data) {
     assert.ifError(err, 'success');
     assert.deepEqual(data, {
       id: changesetId,
@@ -166,7 +166,7 @@ test('[actions.diff] success', function(assert) {
       ChangeSetName: params.ChangeSetName,
       ChangeSetType: 'UPDATE',
       StackName: 'my-stack',
-      Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
+      Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
       Parameters: [
         { ParameterKey: 'Name', ParameterValue: 'Chuck' },
         { ParameterKey: 'Age', ParameterValue: 18 },
@@ -268,7 +268,7 @@ test('[actions.diff] success', function(assert) {
     { ParameterKey: 'SecretPassword', ParameterValue: 'secret' }
   ];
 
-  actions.diff('my-stack', 'us-east-1', 'UPDATE', url, parameters, function(err, data) {
+  actions.diff('my-stack', 'us-east-1', 'UPDATE', url, parameters, false, function(err, data) {
     assert.ifError(err, 'success');
     assert.deepEqual(data, {
       id: 'aa507e2bdfc55947035a07271e75384efe',

--- a/test/actions.test.js
+++ b/test/actions.test.js
@@ -166,7 +166,7 @@ test('[actions.diff] success', function(assert) {
       ChangeSetName: params.ChangeSetName,
       ChangeSetType: 'UPDATE',
       StackName: 'my-stack',
-      Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+      Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
       Parameters: [
         { ParameterKey: 'Name', ParameterValue: 'Chuck' },
         { ParameterKey: 'Age', ParameterValue: 18 },

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -29,9 +29,11 @@ test('[cli.parse] aliases and defaults', function(assert) {
     c: 'config',
     configBucket: 'config',
     p: undefined,
-    parameters: undefined
+    parameters: undefined,
+    x: false,
+    expand: false
   }, 'provided expected options');
-  assert.deepEqual(parsed.overrides, { force: false, kms: false, parameters: undefined }, 'provided expected overrides');
+  assert.deepEqual(parsed.overrides, { force: false, kms: false, parameters: undefined, expand: false }, 'provided expected overrides');
   assert.ok(parsed.help, 'provides help text');
   assert.end();
 });
@@ -41,7 +43,7 @@ test('[cli.parse] sets options', function(assert) {
     'create', 'testing', 'relative/path',
     '-c', 'config',
     '-t', 'template',
-    '-e', '-f', '-d',
+    '-e', '-f', '-d', '-x',
     '-k', 'kms-id',
     '-n', 'my-stack',
     '-r', 'eu-west-1',
@@ -68,9 +70,11 @@ test('[cli.parse] sets options', function(assert) {
     c: 'config',
     configBucket: 'config',
     p: {},
-    parameters: {}
+    parameters: {},
+    x: true,
+    expand: true
   }, 'provided expected options');
-  assert.deepEqual(parsed.overrides, { force: true, kms: 'kms-id', parameters: {} }, 'provided expected overrides');
+  assert.deepEqual(parsed.overrides, { force: true, kms: 'kms-id', parameters: {}, expand: true }, 'provided expected overrides');
 
   assert.end();
 });

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1699,7 +1699,7 @@ test('[commands.operations.getChangeset] failure', function(assert) {
 });
 
 test('[commands.operations.getChangeset] success', function(assert) {
-  assert.plan(7);
+  assert.plan(8);
 
   var details = { changeset: 'details' };
 
@@ -1709,6 +1709,7 @@ test('[commands.operations.getChangeset] success', function(assert) {
     assert.equal(changeSetType, 'UPDATE', 'changeSetType set correctly');
     assert.equal(url, context.templateUrl, 'changeset for the correct template');
     assert.deepEqual(params, context.changesetParameters, 'changeset using changeset parameters');
+    assert.equal(expand, context.overrides.expand, 'changeset using override properties');
     callback(null, details);
   });
 
@@ -1718,6 +1719,7 @@ test('[commands.operations.getChangeset] success', function(assert) {
     newParameters: { new: 'parameters' },
     changesetParameters: { ParameterKey: 'new', ParameterValue: 'parameters' },
     templateUrl: 'https://s3.amazonaws.com/my-template-bucket/my-stack-testing.template.json',
+    overrides: { expand: true },
     abort: function() {
       assert.fail('should not abort');
     },

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1679,7 +1679,7 @@ test('[commands.operations.beforeUpdateHook] hook success', function(assert) {
 });
 
 test('[commands.operations.getChangeset] failure', function(assert) {
-  sinon.stub(actions, 'diff').callsFake(function(name, region, changeSetType, url, params, callback) {
+  sinon.stub(actions, 'diff').callsFake(function(name, region, changeSetType, url, params, expand, callback) {
     callback(new actions.CloudFormationError('failure'));
   });
 
@@ -1703,7 +1703,7 @@ test('[commands.operations.getChangeset] success', function(assert) {
 
   var details = { changeset: 'details' };
 
-  sinon.stub(actions, 'diff').callsFake(function(name, region, changeSetType, url, params, callback) {
+  sinon.stub(actions, 'diff').callsFake(function(name, region, changeSetType, url, params, expand, callback) {
     assert.equal(name, context.stackName, 'changeset for correct stack');
     assert.equal(region, context.stackRegion, 'changeset in the correct region');
     assert.equal(changeSetType, 'UPDATE', 'changeSetType set correctly');


### PR DESCRIPTION
This adds the `CAPABILITY_AUTO_EXPAND` option to the changeset `Capabilities` option. 

### Context

I've been working on creating credentials for an RDS stack that are rotated every 30 days. To _rotate_ these passwords, AWS has a special [`AWS::SecretsManager::RotationSchedule`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-rotationschedule.html) resource that comes with an even more special [`HostedRotationLambda`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-secretsmanager-rotationschedule-hostedrotationlambda.html) that is aware of the type of database in which to rotate the user credentials. Example templates of what these lambdas look like can be found [here](https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_available-rotation-templates.html#sar-template-mysql-multiuser).

To use AWS's hosted lambdas (instead of writing our own) they require two things:

* set `Transform: AWS::SecretsManager-2020-07-23` in the base of your cloudformation temmplate
* include `CAPABILITY_AUTO_EXPAND` in the [UpdateStack or CreateStack actions](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStack.html)

Without the additional capability, the stack creation fails with the following errors:

```
19:31:20Z eu-west-1: CREATE_FAILED CredentialsRotationScheduleHostedRotationLambda: Requires capabilities : [CAPABILITY_AUTO_EXPAND]
```

### Testing & next steps

I updated cfn-config on my local computer and `npm link`'d to test the change, and the stack creation + update worked! Are there downsides to including this option in cfn-config? 

cc @rclark  (h/t @mattficke for pointing me in the right direction)



