### PR TITLE
Requires an explicit answer from the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
+## 3.3 - 2023-09-12
+- Change default when confirming template changes from "No" to keep prompting the user until a valid choice is provided
+
 ## 3.2.2 - 2022-09-07
 - Update Meow to v7.1.1
 

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -541,10 +541,22 @@ var operations = module.exports.operations = {
       'Accept changes and update the stack?'
     ].join('\n');
 
-    prompt.confirm(msg, false, function(err, ready) {
-      if (!ready) return context.abort();
-      context.next();
-    });
+    while (true) {
+      // Loop until user makes an explicit choice
+      prompt.confirm(msg, "MAGIC_PATTERN_REQUIRE_RESPONSE", function(err, ready) {
+        if (ready === "MAGIC_PATTERN_REQUIRE_RESPONSE") {
+          // User made no explicit choice, replay the prompt
+          return;
+        }
+        if (ready === false) {
+          // User did not accept changes
+          return context.abort();
+        } else {
+          // User did accept changes
+        context.next();
+        }
+      });
+    }
   },
 
   executeChangeSet: function(context) {

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -541,22 +541,13 @@ var operations = module.exports.operations = {
       'Accept changes and update the stack?'
     ].join('\n');
 
-    while (true) {
-      // Loop until user makes an explicit choice
-      prompt.confirm(msg, "MAGIC_PATTERN_REQUIRE_RESPONSE", function(err, ready) {
-        if (ready === "MAGIC_PATTERN_REQUIRE_RESPONSE") {
-          // User made no explicit choice, replay the prompt
-          return;
-        }
-        if (ready === false) {
-          // User did not accept changes
-          return context.abort();
-        } else {
-          // User did accept changes
+    prompt.yesOrNo(msg, function(err, confirmed) {
+      if (confirmed) {
         context.next();
-        }
-      });
-    }
+      } else {
+        return context.abort();
+      }
+    });
   },
 
   executeChangeSet: function(context) {

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -3,7 +3,11 @@ var inquirer = require('inquirer');
 var prompt = module.exports = {};
 
 /**
- * Confirm an action with a yes/no prompt
+ * Confirm an action with a yes/no prompt. This accepts a default value, but
+ * defaults to true (yes) if no default is provided.
+ * 
+ * If you want to force the user to type out "yes" or "no" or variations thereof, use prompt.yesOrNo
+ * instead.
  *
  * @param {string} message - a question for the user to answer yes or no
  * @param {boolean} default - boolean to use as default. if omitted, defaults to true (yes)
@@ -30,6 +34,53 @@ prompt.confirm = function(message, defaultValue, callback) {
     default: defaultValue
   }).then(function(answers) {
     callback(null, answers.confirmation);
+  });
+};
+
+/**
+ * Confirm an action with a yes/no prompt. This does not accept a default value.
+ * 
+ * The callback will be presented with a boolean value (true for yes, false for no), instead of a string value
+ *
+ * @param {string} message - a question for the user to answer yes or no in a variety of ways.
+ * @param {function} callback - a function fired with the user's response as a boolean
+ */
+prompt.yesOrNo = function(message, callback) {
+  var lines = message.split('\n');
+
+  if (lines.length > 1) {
+    message = lines.pop();
+    lines.unshift('');
+    lines.push('');
+    process.stdout.write(lines.join('\n'));
+  }
+  const validYeses = ['y', 'Y'];
+  const validNos = ['n', 'N'];
+
+  inquirer.prompt({
+    type: 'input',
+    name: 'confirmation',
+    defaultValue: undefined,
+    message: `${message} (y/n)`,
+    validate: function(input) {
+      if (validYeses.includes(input) || validNos.includes(input)) {
+        return true;
+      }
+
+      return 'Please enter y or n';
+    },
+  }).then(function(answers) {
+    const toBooleanFlag = (possibleConfirmation) => {
+      if (validYeses.includes(possibleConfirmation)) {
+        return true;
+      }
+
+      if (validNos.includes(possibleConfirmation)) {
+        return false;
+      }
+      throw new Error(`Invalid input: ${possibleConfirmation}. Please enter y or n`);
+    };
+    callback(null, toBooleanFlag(answers.confirmation));
   });
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/cfn-config",
-  "version": "3.2.2",
+  "version": "3.2.3-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/cfn-config",
-      "version": "3.2.2",
+      "version": "3.2.3-rc.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "aws-sdk": "^2.720.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/cfn-config",
-  "version": "3.2.3-rc.0",
+  "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/cfn-config",
-      "version": "3.2.3-rc.0",
+      "version": "3.3.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "aws-sdk": "^2.720.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git"
   },
   "author": "Mapbox",
-  "version": "3.2.3-rc.0",
+  "version": "3.3.0",
   "dependencies": {
     "aws-sdk": "^2.720.0",
     "cfn-stack-event-stream": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git"
   },
   "author": "Mapbox",
-  "version": "3.2.2",
+  "version": "3.2.3-rc.0",
   "dependencies": {
     "aws-sdk": "^2.720.0",
     "cfn-stack-event-stream": "^1.0.1",

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1801,8 +1801,7 @@ test('[commands.operations.confirmChangeset] skipConfirmParams && skipConfirmTem
 });
 
 test('[commands.operations.confirmChangeset] rejected', function(assert) {
-  sinon.stub(prompt, 'confirm').callsFake(function(message, defaultValue, callback) {
-    assert.equal(defaultValue, false);
+  sinon.stub(prompt, 'yesOrNo').callsFake(function(message, callback) {
     callback(null, false);
   });
 
@@ -1810,7 +1809,7 @@ test('[commands.operations.confirmChangeset] rejected', function(assert) {
     changeset: { changes: [] },
     abort: function(err) {
       assert.ifError(err, 'aborted');
-      prompt.confirm.restore();
+      prompt.yesOrNo.restore();
       assert.end();
     }
   });
@@ -1818,12 +1817,11 @@ test('[commands.operations.confirmChangeset] rejected', function(assert) {
   commands.operations.confirmChangeset(context);
 });
 
-test('[commands.operations.confirmChangeset] acccepted', function(assert) {
-  assert.plan(3);
+test('[commands.operations.confirmChangeset] accepted', function(assert) {
+  assert.plan(2);
 
-  sinon.stub(prompt, 'confirm').callsFake(function(message, defaultValue, callback) {
+  sinon.stub(prompt, 'yesOrNo').callsFake(function(message, callback) {
     assert.equal(message, '\n\n\nAccept changes and update the stack?', 'expected message');
-    assert.equal(defaultValue, false);
     callback(null, true);
   });
 
@@ -1834,7 +1832,8 @@ test('[commands.operations.confirmChangeset] acccepted', function(assert) {
     },
     next: function() {
       assert.pass('success');
-      prompt.confirm.restore();
+      prompt.yesOrNo.restore();
+      assert.end();
     }
   });
 
@@ -1842,9 +1841,8 @@ test('[commands.operations.confirmChangeset] acccepted', function(assert) {
 });
 
 test('[commands.operations.confirmChangeset] changeset formatting', function(assert) {
-  sinon.stub(prompt, 'confirm').callsFake(function(message, defaultValue, callback) {
+  sinon.stub(prompt, 'yesOrNo').callsFake(function(message, callback) {
     assert.equal(message, 'Action  Name  Type  Replace\n------  ----  ----  -------\n\x1b[33mModify\x1b[39m  name  type  \x1b[31mtrue\x1b[39m   \n\x1b[32mAdd\x1b[39m     name  type  \x1b[32mfalse\x1b[39m  \n\x1b[31mRemove\x1b[39m  name  type  \x1b[32mfalse\x1b[39m  \n\nAccept changes and update the stack?', 'expected message (with colors)');
-    assert.equal(defaultValue, false);
     callback(null, true);
   });
 
@@ -1861,7 +1859,7 @@ test('[commands.operations.confirmChangeset] changeset formatting', function(ass
     },
     next: function() {
       assert.pass('success');
-      prompt.confirm.restore();
+      prompt.yesOrNo.restore();
       assert.end();
     }
   });

--- a/test/prompt.test.js
+++ b/test/prompt.test.js
@@ -64,6 +64,49 @@ test('[prompt.confirm] multi-line, reject', function(assert) {
   });
 });
 
+test('[prompt.yesOrNo] single-line, confirm', function(assert) {
+  sinon.stub(inquirer, 'prompt').callsFake(function(questions) {
+    assert.equal(questions.type, 'input', 'called with correct prompt type');
+    assert.equal(questions.name, 'confirmation', 'called with correct capture name');
+    assert.equal(questions.message, 'confirm? (y/n)', 'called with correct message');
+
+    return Promise.resolve({ confirmation: 'y' });
+  });
+  prompt.yesOrNo('confirm?', function(err, confirmed) {
+    assert.ifError(err, 'success');
+    assert.ok(confirmed, 'received user confirmation');
+    inquirer.prompt.restore();
+    assert.end();
+  });
+});
+
+test('[prompt.yesOrNo] single-line, reject', function(assert) {
+  sinon.stub(inquirer, 'prompt').callsFake(function(questions) {
+    assert.equal(questions.type, 'input', 'called with correct prompt type');
+    assert.equal(questions.name, 'confirmation', 'called with correct capture name');
+    assert.equal(questions.message, 'confirm? (y/n)', 'called with correct message');
+
+    return Promise.resolve({ confirmation: 'n' });
+    
+  });
+  prompt.yesOrNo('confirm?', function(err, confirmed) {
+    assert.ifError(err, 'success');
+    assert.notOk(confirmed, 'received user rejection');
+    inquirer.prompt.restore();
+    assert.end();
+  });
+});
+
+test('[prompt.yesOrNo] single-line, invalid-input-then-valid', (assert) => {
+  prompt.yesOrNo('confirm?', function(err, confirmed) {
+    assert.ifError(err, 'success');
+    assert.ok(confirmed, 'received user confirmation');
+    assert.end();
+  });
+  process.stdin.emit('keypress', 'foo\r');
+  process.stdin.emit('keypress', 'y\r');
+});
+
 test('[prompt.configuration] success', function(assert) {
   sinon.stub(inquirer, 'prompt').callsFake(function(questions) {
     assert.deepEqual(questions, {


### PR DESCRIPTION
I have so many times lost all the input I made in the `--interview` prompt of `mbxcli` due to the final `? Accept changes and update the stack?` prompt defaulting to false and thus aborting everything even if the user just inputs nothing (aka just `enter` one time too many).

This changes this code to require an actual explicit input from the user. Otherwise the prompt is replayed again.
