### PR TITLE
Update the diff module to v5.2.0 for performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
+# 3.3.1 - 2024-04-18
+- Update `diff` to v5.2.0
+
 ## 3.3 - 2023-09-12
 - Change default when confirming template changes from "No" to keep prompting the user until a valid choice is provided
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "colors": "1.4.0",
         "cuid": "^2.1.1",
         "d3-queue": "^3.0.2",
-        "diff": "^3.5.0",
+        "diff": "^5.2.0",
         "easy-table": "^1.0.0",
         "fasterror": "^1.0.0",
         "inquirer": "^8.2.0",
@@ -403,6 +403,15 @@
       "dev": true,
       "dependencies": {
         "samsam": "1.3.0"
+      }
+    },
+    "node_modules/@mapbox/mock-aws-sdk-js/node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/@mapbox/mock-aws-sdk-js/node_modules/sinon": {
@@ -1130,9 +1139,9 @@
       "dev": true
     },
     "node_modules/diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -4162,6 +4171,15 @@
         "type-detect": "^4.0.8"
       }
     },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -5236,6 +5254,12 @@
             "samsam": "1.3.0"
           }
         },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
         "sinon": {
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
@@ -5804,9 +5828,9 @@
       "dev": true
     },
     "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A=="
     },
     "difflib": {
       "version": "0.2.4",
@@ -8102,6 +8126,14 @@
         "nise": "^1.4.5",
         "supports-color": "^5.5.0",
         "type-detect": "^4.0.8"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        }
       }
     },
     "slice-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/cfn-config",
-  "version": "3.3.1-dev",
+  "version": "3.3.1-dev2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/cfn-config",
-      "version": "3.3.1-dev",
+      "version": "3.3.1-dev2",
       "license": "BSD-2-Clause",
       "dependencies": {
         "aws-sdk": "^2.720.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/cfn-config",
-  "version": "3.3.0",
+  "version": "3.3.1-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/cfn-config",
-      "version": "3.3.0",
+      "version": "3.3.1-dev",
       "license": "BSD-2-Clause",
       "dependencies": {
         "aws-sdk": "^2.720.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "colors": "1.4.0",
     "cuid": "^2.1.1",
     "d3-queue": "^3.0.2",
-    "diff": "^3.5.0",
+    "diff": "^5.2.0",
     "easy-table": "^1.0.0",
     "fasterror": "^1.0.0",
     "inquirer": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git"
   },
   "author": "Mapbox",
-  "version": "3.3.0",
+  "version": "3.3.1-dev",
   "dependencies": {
     "aws-sdk": "^2.720.0",
     "cfn-stack-event-stream": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git"
   },
   "author": "Mapbox",
-  "version": "3.3.1-dev",
+  "version": "3.3.1-dev2",
   "dependencies": {
     "aws-sdk": "^2.720.0",
     "cfn-stack-event-stream": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git"
   },
   "author": "Mapbox",
-  "version": "3.3.1-dev2",
+  "version": "3.3.0",
   "dependencies": {
     "aws-sdk": "^2.720.0",
     "cfn-stack-event-stream": "^1.0.1",


### PR DESCRIPTION
Update `diff` from v3.5.0 to v5.2.0. The update includes significant performance improvements ([jsdiff/#448](https://github.com/kpdecker/jsdiff/pull/448) & [jsdiff/#411](https://github.com/kpdecker/jsdiff/pull/411)) which makes it possible to diff larger CloudFormation templates.

For a full list of changes, see the changelog: https://github.com/kpdecker/jsdiff/blob/master/release-notes.md.

### Review of breaking changes between version 3.5.0 and 5.2.0

#### v5.0.0
> - Breaking: UMD export renamed from JsDiff to Diff.

We are not affected, since cfn-config doesn't use UMD imports.

> - Breaking: Newlines separated into separate tokens for word diff.

Changes in https://github.com/kpdecker/jsdiff/pull/217 affect the diff return value of the `diffWords` function. We don't use `diffWords`in cfn.config.

> - Breaking: Unified diffs now match ["quirks"](https://www.artima.com/weblogs/viewpost.jsp?thread=164293)

cfn-config doesn't use the unified diff output. The changes in https://github.com/kpdecker/jsdiff/pull/297 affect how unified diff chunks are formatted. 
  
#### v4.0.0 - January 5th, 2019
> - https://github.com/kpdecker/jsdiff/issues/94 - Missing "No newline at end of file" when comparing two texts that do not end in newlines ([@federicotdn](https://api.github.com/users/federicotdn))

Changes in https://github.com/kpdecker/jsdiff/issues/94 affect only patches in unified diff format, which are not used in cfn-config.

> - https://github.com/kpdecker/jsdiff/issues/159 - applyPatch affecting wrong line number with with new lines

Changes affect only patches in unified diff format, which are not used in cfn-config.

>- Drop ie9 from karma targets - 79c31bd

cfn-config is not affected by browser targets.

> - Make ()[]"' as word boundaries between each other - f27b899

Changes in https://github.com/kpdecker/jsdiff/commit/f27b899 affect word diffs, which are not used in cfn-config.

> - Compatibility notes: Bower and Component packages no longer supported
 
 cfn-config doesn't use bower.