### PR TITLE
CLOUDPLAT-3162: add npm-release environment gate (cfn-config)

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -9,5 +9,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
+    environment: npm-release
     with:
       create-github-release: true

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git"
   },
   "author": "Mapbox",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "dependencies": {
     "aws-sdk": "^2.720.0",
     "cfn-stack-event-stream": "^1.0.1",


### PR DESCRIPTION
Adding `environment: npm-release` to the npm release workflow.